### PR TITLE
Simplify start import

### DIFF
--- a/src/components/import-modal/import-modal.jsx
+++ b/src/components/import-modal/import-modal.jsx
@@ -56,7 +56,8 @@ class ImportModal extends PureComponent {
     stopOnErrors: PropTypes.bool,
     setStopOnErrors: PropTypes.func,
     ignoreEmptyFields: PropTypes.bool,
-    setIgnoreEmptyFields: PropTypes.func
+    setIgnoreEmptyFields: PropTypes.func,
+    guesstimatedDocsTotal: PropTypes.number
   };
 
   getStatusMessage() {
@@ -210,6 +211,7 @@ class ImportModal extends PureComponent {
             message={this.getStatusMessage()}
             cancel={this.props.cancelImport}
             docsWritten={this.props.docsWritten}
+            guesstimatedDocsTotal={this.props.guesstimatedDocsTotal}
           />
           <ErrorBox error={this.props.error} />
         </Modal.Body>
@@ -249,7 +251,7 @@ const mapStateToProps = state => ({
   fileName: state.importData.fileName,
   status: state.importData.status,
   docsWritten: state.importData.docsWritten,
-  docsTotal: state.importData.docsTotal,
+  guesstimatedDocsTotal: state.importData.guesstimatedDocsTotal,
   delimiter: state.importData.delimiter,
   stopOnErrors: state.importData.stopOnErrors,
   ignoreEmptyFields: state.importData.ignoreEmptyFields

--- a/src/components/progress-bar/progress-bar.jsx
+++ b/src/components/progress-bar/progress-bar.jsx
@@ -1,7 +1,13 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import {STARTED, CANCELED, COMPLETED, FAILED, UNSPECIFIED} from 'constants/process-status';
+import {
+  STARTED,
+  CANCELED,
+  COMPLETED,
+  FAILED,
+  UNSPECIFIED
+} from 'constants/process-status';
 
 import styles from './progress-bar.less';
 import createStyler from 'utils/styler.js';
@@ -20,8 +26,9 @@ class ProgressBar extends PureComponent {
     status: PropTypes.string.isRequired,
     message: PropTypes.string.isRequired,
     docsWritten: PropTypes.number,
-    docsTotal: PropTypes.number, // <==- handle undefined for import
-    cancel: PropTypes.func
+    docsTotal: PropTypes.number,
+    cancel: PropTypes.func,
+    guesstimatedDocsTotal: PropTypes.number // <- for import only
   };
 
   /**
@@ -52,11 +59,16 @@ class ProgressBar extends PureComponent {
 
     return (
       // eslint-disable-next-line no-script-url
-      <a className={style('status-message-cancel')} onClick={(evt)=> {
-        evt.stopPropagation();
-        evt.preventDefault();
-        this.props.cancel();
-      }}>Cancel</a>
+      <a
+        className={style('status-message-cancel')}
+        onClick={evt => {
+          evt.stopPropagation();
+          evt.preventDefault();
+          this.props.cancel();
+        }}
+      >
+        Cancel
+      </a>
     );
   }
 
@@ -67,7 +79,13 @@ class ProgressBar extends PureComponent {
     // Could use the estimate set in modules/import progress?
     if (docsTotal === undefined) {
       return (
-        <p className={style('status-stats')}>
+        <p
+          className={style('status-stats')}
+          title={
+            'Guesstimated total: ' +
+            formatNumber(this.props.guesstimatedDocsTotal)
+          }
+        >
           {formatNumber(docsWritten)}
           &nbsp;({formatNumber(progress)}%)
         </p>
@@ -87,13 +105,13 @@ class ProgressBar extends PureComponent {
    * @returns {React.Component} The component.
    */
   render() {
-    const {message, progress, status} = this.props;
+    const { message, progress, status } = this.props;
     if (status === UNSPECIFIED) {
       return null;
     }
 
     return (
-      <div className="well" style={{padding: '20px', marginBottom: '0px'}}>
+      <div className="well" style={{ padding: '20px', marginBottom: '0px' }}>
         <div className={style()}>
           <div
             className={this.getBarClassName()}
@@ -102,7 +120,8 @@ class ProgressBar extends PureComponent {
         </div>
         <div className={styles['progress-bar-status']}>
           <p className={this.getMessageClassName()}>
-            {message}{this.maybeCancelButton()}
+            {message}
+            {this.maybeCancelButton()}
           </p>
           {this.renderStats()}
         </div>

--- a/src/modules/import.js
+++ b/src/modules/import.js
@@ -291,6 +291,7 @@ export const startImport = () => {
       }
     });
 
+    const stripBOM = stripBomStream();
 
     const throttle = require('lodash.throttle');
     function update_import_progress_throttled(info) {
@@ -318,7 +319,7 @@ export const startImport = () => {
     dispatch(onStarted(source, dest));
     stream.pipeline(
       source,
-      stripBomStream(),
+      stripBOM,
       parser,
       sizer,
       progress,

--- a/src/modules/import.js
+++ b/src/modules/import.js
@@ -321,6 +321,10 @@ export const startImport = () => {
       removeEmptyFields,
       dest,
       function(err, res) {
+        /**
+         * TODO: lucas: Decorate with a codeframe if not already
+         * json parsing errors already are.
+         */
         if (err) {
           return dispatch(onError(err));
         }
@@ -350,7 +354,7 @@ export const cancelImport = () => {
     }
     debug('cancelling');
     source.unpipe();
-    dest.end();
+    // dest.end();
     debug('import canceled by user');
     dispatch({ type: CANCELED });
   };

--- a/src/utils/import-size-guesstimator.js
+++ b/src/utils/import-size-guesstimator.js
@@ -1,0 +1,52 @@
+/* eslint-disable no-console */
+import { Transform } from 'stream';
+const sizeof = require('object-sizeof');
+
+export default function createImportSizeGuesstimator(
+  source,
+  fileTotalSize,
+  onGuesstimate
+) {
+  // TODO: lucas: this kinda works now :) could be way better
+  // BUT good enough for now.
+  return new Transform({
+    objectMode: true,
+    transform: function(chunk, encoding, cb) {
+      if (!this.sizes) {
+        this.sizes = [];
+        this._done = false;
+        this.lastBytesRead = 0;
+      }
+
+      if (this._done === true) {
+        return cb(null, chunk);
+      }
+      this.sizes.push(sizeof(chunk));
+      /**
+       * fs reads files in 64 kb blocks (default highwatermark for createReadStream()
+       * So the first time our stream gets data on or after 64 kb,
+       * we can say the number of docs our stream has seen so far
+       * is the number of docs in the file.
+       */
+      if (
+        source.bytesRead >= 65536 &&
+        !this._done &&
+        this.sizes.length === 1000
+      ) {
+        this._done = true;
+        const bytesPerDoc = source.bytesRead / this.sizes.length;
+        const estimatedTotalDocs = fileTotalSize / bytesPerDoc;
+        onGuesstimate(null, estimatedTotalDocs);
+
+        console.group('Object Size estimator');
+        console.log('source.bytesRead', source.bytesRead);
+        console.log('bytesPerDoc', bytesPerDoc);
+        console.log('docs seen', this.sizes.length);
+        console.log('est docs', estimatedTotalDocs);
+        console.log('js object sizes for docs seen', this.sizes);
+        console.groupEnd();
+      }
+      return cb(null, chunk);
+    }
+  });
+}

--- a/src/utils/import-size-guesstimator.js
+++ b/src/utils/import-size-guesstimator.js
@@ -26,7 +26,7 @@ export default function createImportSizeGuesstimator(
        * fs reads files in 64 kb blocks (default highwatermark for createReadStream()
        * So the first time our stream gets data on or after 64 kb,
        * we can say the number of docs our stream has seen so far
-       * is the number of docs in the file.
+       * might be pretty close to the number of docs in the file.
        */
       if (
         source.bytesRead >= 65536 &&

--- a/src/utils/import-size-guesstimator.spec.js
+++ b/src/utils/import-size-guesstimator.spec.js
@@ -1,0 +1,42 @@
+// https://jira.mongodb.org/browse/COMPASS-3015
+// ~/Downloads/DOB_Permit_Issuance-000.csv
+//
+// 92,782,967 bytes 200,000 docs
+// 92782967/200000
+// 463.914835 bytes per doc
+
+// Object Size estimator
+// import-size-guesstimator.js?6e25:45 source.bytesRead 458752
+// import-size-guesstimator.js?6e25:46 bytesPerDoc 458.752
+// import-size-guesstimator.js?6e25:47 docs seen 1000
+// import-size-guesstimator.js?6e25:48 est docs 202250.81743512835
+import { createCSVParser } from './parsers';
+import createImportSizeGuesstimator from './import-size-guesstimator';
+import { pipeline } from 'stream';
+
+// TODO: lucas: This works functionally in electron but can't
+// figure out how/why in mocha-webpack.
+describe.skip('guesstimator', () => {
+  it('should guess', function(done) {
+    this.timeout(5000);
+    const FILE_SIZE = 92782967;
+    const fs = require('fs');
+    const source = fs.createReadStream(
+      '/Users/lucas/Downloads/DOB_Permit_Issuance-000.csv'
+    );
+    const parser = createCSVParser();
+    const guesstimator = createImportSizeGuesstimator(
+      source,
+      FILE_SIZE,
+      function(err, guess) {
+        if (err) return done(err);
+
+        console.log('guess is', guess);
+      }
+    );
+    pipeline(source, parser, guesstimator, function(err) {
+      console.log('done');
+      return done(err);
+    });
+  });
+});

--- a/src/utils/remove-empty-fields.js
+++ b/src/utils/remove-empty-fields.js
@@ -1,3 +1,5 @@
+import { Transform, PassThrough } from 'stream';
+
 /**
  * Based on mongoimport implementation.
  * https://github.com/mongodb/mongo-tools/blob/b1d68af3de3244484d8a7dddd939782d749b2b5c/mongoimport/common.go#L239
@@ -22,6 +24,18 @@ function removeEmptyFields(data) {
     doc[key] = removeEmptyFields(data[key]);
     return doc;
   }, {});
+}
+
+export function removeEmptyFieldsStream(ignoreEmptyFields) {
+  if (!ignoreEmptyFields) {
+    return new PassThrough();
+  }
+  return new Transform({
+    objectMode: true,
+    transform: function(doc, encoding, cb) {
+      cb(null, removeEmptyFields(doc));
+    }
+  });
 }
 
 export default removeEmptyFields;


### PR DESCRIPTION
This PR is refactoring to minimize logic within `startImport()` and allow fine-grained testing of stream-based components now that we're confident they'll stick around.