### PR TITLE
chore: update travis server version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
   - 10.2.1
 env:
   matrix:
-    - MONGODB_VERSION=3.4.x MONGODB_TOPOLOGY=standalone
+    - MONGODB_VERSION=stable MONGODB_TOPOLOGY=standalone
 addons:
   apt:
     sources:


### PR DESCRIPTION
This PR updates the travis config so that functional tests now tests against latest stable server version (currently 4.2.x) instead of hardcoded `3.4.x` (😬) .