### PR TITLE
COMPASS-3948: refresh data on import error and on complete

### DIFF
--- a/src/modules/compass/app-registry.spec.js
+++ b/src/modules/compass/app-registry.spec.js
@@ -30,9 +30,9 @@ describe('app-registry [module]', () => {
 
   describe('#appRegistryEmit', () => {
     it('returns the action', () => {
-      expect(actions.appRegistryEmit('refresh-documents', spy)).to.deep.equal({
+      expect(actions.appRegistryEmit('refresh-data', spy)).to.deep.equal({
         type: actions.EMIT,
-        name: 'refresh-documents',
+        name: 'refresh-data',
         args: [ spy ]
       });
     });

--- a/src/modules/import.js
+++ b/src/modules/import.js
@@ -313,6 +313,11 @@ export const startImport = () => {
       dest,
       function(err, res) {
         /**
+        * refresh data (docs, aggregations) regardless of whether we have a
+        * partial import or full import
+        */
+        dispatch(appRegistryEmit('refresh-data'));
+        /**
          * TODO: lucas: Decorate with a codeframe if not already
          * json parsing errors already are.
          */

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -1,5 +1,7 @@
 /* eslint-disable no-var */
 /* eslint-disable callback-return */
+/* eslint-disable complexity */
+
 import csv from 'fast-csv';
 import { EJSON } from 'bson';
 import { Transform } from 'stream';

--- a/src/utils/styler.js
+++ b/src/utils/styler.js
@@ -1,3 +1,4 @@
+/* eslint-disable space-infix-ops */
 
 /**
  * Create a helper function for accessing a component's class name.


### PR DESCRIPTION
## Description
`appRegistry` to emit a `refresh-data` event when import is partially or fully finished. This event is listened to by docs/indexes/aggregations so we should be covered in all instances.

## Type of Changes
- [x] Patch