### PR TITLE
feat: Travis deploys storybook to ghpages on successful builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ script:
 cache: npm
 after_success:
   - npm run storybook:ghpages
-  - rm .npmrc
 deploy:
   # Push to GitHub Pages
   - provider: pages
@@ -36,6 +35,5 @@ deploy:
     github-token: $GITHUB_TOKEN
     keep-history: true
     local_dir: .ghpages
-    # TODO: lucas: just for testing until PR ready
-    # on:
-    #   branch: master
+    on:
+      branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,24 @@ addons:
       - libsecret-1-dev
       - gnome-keyring
       - python-gnomekeyring
+install:
+  - npm ci
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-script: npm run ci
-cache:
-  directories:
-    - $HOME/.electron
-    - node_modules
+script:
+  - npm run cover
+cache: npm
+after_success:
+  - npm run storybook:ghpages
+  - rm .npmrc
+deploy:
+  # Push to GitHub Pages
+  - provider: pages
+    skip-cleanup: true
+    github-token: $GITHUB_TOKEN
+    keep-history: true
+    local_dir: .ghpages
+    # TODO: lucas: just for testing until PR ready
+    # on:
+    #   branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ addons:
       - libsecret-1-dev
       - gnome-keyring
       - python-gnomekeyring
+before_install:
+  - npm i -g npm@latest
 install:
   - npm ci
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,5 +35,5 @@ deploy:
     github-token: $GITHUB_TOKEN
     keep-history: true
     local_dir: .ghpages
-    on:
-      branch: master
+    # on:
+    #   branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,5 +35,5 @@ deploy:
     github-token: $GITHUB_TOKEN
     keep-history: true
     local_dir: .ghpages
-    # on:
-    #   branch: master
+    on:
+      branch: master

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "start": "webpack-dev-server --config ./config/webpack.dev.config.js",
     "test": "cross-env NODE_ENV=test mocha-webpack \"./src/**/*.spec.js\"",
     "cover": "nyc npm run test",
-    "ci": "npm run cover",
     "check": "mongodb-js-precommit './src/**/*{.js,.jsx}' './test/**/*.js'",
     "prepublishOnly": "npm run compile",
     "storybook": "cross-env NODE_ENV=development start-storybook -p 9001 -c .storybook",


### PR DESCRIPTION
This PR configures `compass-import-export` to deploy [its storybook](https://github.com/mongodb-js/compass-import-export/tree/master/examples) to GitHub pages after the master branch successfully builds and passes tests. This configuration follows the same model as [compass-aggregations](https://mongodb-js.github.io/compass-aggregations).

 