### PR TITLE
COMPASS-3949: buttons based on current import state

### DIFF
--- a/src/components/import-modal/import-modal.jsx
+++ b/src/components/import-modal/import-modal.jsx
@@ -119,6 +119,45 @@ class ImportModal extends PureComponent {
     }
   };
 
+  renderDoneButton() {
+    if (this.props.status === COMPLETED) {
+      return (
+        <TextButton
+          className="btn btn-primary btn-sm"
+          text="DONE"
+          clickHandler={this.handleClose}
+        />
+      );
+    }
+  }
+
+  renderCancelButton() {
+    if (this.props.status !== COMPLETED) {
+      return (
+        <TextButton
+          className="btn btn-default btn-sm"
+          text={
+            FINISHED_STATUSES.includes(this.props.status) ? 'Close' : 'Cancel'
+          }
+          clickHandler={this.handleClose}
+        />
+      );
+    }
+  }
+
+  renderImportButton() {
+    if (this.props.status !== COMPLETED) {
+      return (
+        <TextButton
+          className="btn btn-primary btn-sm"
+          text={this.props.status === STARTED ? 'Importing...' : 'Import'}
+          disabled={!this.props.fileName || this.props.status === STARTED}
+          clickHandler={this.handleImportBtnClicked}
+        />
+      );
+    }
+  }
+
   renderOptions() {
     const isCSV = this.props.fileType === FILE_TYPES.CSV;
     return (
@@ -216,19 +255,9 @@ class ImportModal extends PureComponent {
           <ErrorBox error={this.props.error} />
         </Modal.Body>
         <Modal.Footer>
-          <TextButton
-            className="btn btn-default btn-sm"
-            text={
-              FINISHED_STATUSES.includes(this.props.status) ? 'Close' : 'Cancel'
-            }
-            clickHandler={this.handleClose}
-          />
-          <TextButton
-            className="btn btn-primary btn-sm"
-            text={this.props.status === STARTED ? 'Importing...' : 'Import'}
-            disabled={!this.props.fileName || this.props.status === STARTED}
-            clickHandler={this.handleImportBtnClicked}
-          />
+          {this.renderCancelButton()}
+          {this.renderImportButton()}
+          {this.renderDoneButton()}
         </Modal.Footer>
       </Modal>
     );

--- a/src/components/progress-bar/progress-bar.jsx
+++ b/src/components/progress-bar/progress-bar.jsx
@@ -52,25 +52,24 @@ class ProgressBar extends PureComponent {
     });
   }
 
-  maybeCancelButton() {
+  getCancelButton() {
     if (this.props.status !== STARTED) {
       return null;
     }
 
     return (
       // eslint-disable-next-line no-script-url
-      <a
-        className={style('status-message-cancel')}
-        onClick={evt => {
-          evt.stopPropagation();
-          evt.preventDefault();
-          this.props.cancel();
-        }}
-      >
-        Cancel
+      <a className={style('status-message-cancel')} onClick={this.handleCancel}>
+        Stop 
       </a>
     );
   }
+
+  handleCancel = (evt) => {
+    evt.stopPropagation();
+    evt.preventDefault();
+    this.props.cancel();
+  };
 
   renderStats() {
     const { docsTotal, docsWritten, progress } = this.props;
@@ -82,7 +81,7 @@ class ProgressBar extends PureComponent {
         <p
           className={style('status-stats')}
           title={
-            'Guesstimated total: ' +
+            'Estimated total: ' +
             formatNumber(this.props.guesstimatedDocsTotal)
           }
         >
@@ -111,7 +110,7 @@ class ProgressBar extends PureComponent {
     }
 
     return (
-      <div className="well" style={{ padding: '20px', marginBottom: '0px' }}>
+      <div className={style('chart-wrapper')}>
         <div className={style()}>
           <div
             className={this.getBarClassName()}
@@ -121,7 +120,7 @@ class ProgressBar extends PureComponent {
         <div className={styles['progress-bar-status']}>
           <p className={this.getMessageClassName()}>
             {message}
-            {this.maybeCancelButton()}
+            {this.getCancelButton()}
           </p>
           {this.renderStats()}
         </div>

--- a/src/components/progress-bar/progress-bar.less
+++ b/src/components/progress-bar/progress-bar.less
@@ -7,7 +7,7 @@
   background-color: #e7eeec;
 
   &-chart-wrapper {
-    padding: 20px;
+    padding-top: 20px;
     margin-bottom: 0px;
   }
 
@@ -38,9 +38,12 @@
 
     &-message {
       flex-grow: 1;
+      margin-bottom: 0;
+
       &-is-failed {
         color: #d65d33;
       }
+
       &-cancel {
         margin-left: 10px;
         color: #0d47a1;
@@ -49,6 +52,7 @@
     }
     &-stats {
       flex-grow: 0;
+      margin-bottom: 0;
     }
   }
 }

--- a/src/components/progress-bar/progress-bar.less
+++ b/src/components/progress-bar/progress-bar.less
@@ -6,6 +6,11 @@
   height: 10px;
   background-color: #e7eeec;
 
+  &-chart-wrapper {
+    padding: 20px;
+    margin-bottom: 0px;
+  }
+
   &-bar {
     height: 10px;
     transition: width 0.2s ease;


### PR DESCRIPTION
## Description
Configures import buttons based on current import state. 
- `Cancel` and `Import` are present when file is not yet imported
- `Close` and `Import` are present when file import was stopped
- `...Importing` is present as disabled when file is in the middle of import
- `Stop` anchor link is present along with a progress bar
- `Done` button is present after import successfully completed

Result looks like this:
![MOgeOInbOd](https://user-images.githubusercontent.com/8107784/68025406-eea6e400-fcac-11e9-8910-e1ff7438f490.gif)

## Types of changes
- [x] Patch (non-breaking change which fixes an issue)