### PR TITLE
[WIP] get localAppRegistry from state via _emitter

### DIFF
--- a/src/modules/compass/app-registry.js
+++ b/src/modules/compass/app-registry.js
@@ -21,7 +21,8 @@ const reducer = (state = INITIAL_STATE, action) => {
   }
 
   if (action.type === EMIT) {
-    const { appRegistry, globalAppRegistry } = state;
+    const appRegistry = state._emitter;
+    // TODO: Irina, figure out under what `globalAppRegistry` is stored
     if (appRegistry) {
       appRegistry.emit(action.name, ...action.args);
     }

--- a/src/modules/import.js
+++ b/src/modules/import.js
@@ -313,15 +313,11 @@ export const startImport = () => {
       dest,
       function(err, res) {
         /**
-        * refresh data (docs, aggregations) regardless of whether we have a
-        * partial import or full import
-        */
-        dispatch(appRegistryEmit('refresh-data'));
-        /**
          * TODO: lucas: Decorate with a codeframe if not already
          * json parsing errors already are.
          */
         if (err) {
+          dispatch(appRegistryEmit('refresh-data'));
           return dispatch(onError(err));
         }
         /**
@@ -330,6 +326,7 @@ export const startImport = () => {
          */
         debug('done', err, res);
         dispatch(onFinished(dest.docsWritten));
+        dispatch(appRegistryEmit('refresh-data'));
         dispatch(appRegistryEmit('import-finished', size, fileType));
       }
     );


### PR DESCRIPTION
## Description
`globalAppRegistry` and `localAppRegistry` are not stored under their respective names, but as `_emitter`. When emitting, use `_emitter`. 

## Motivation and Context
I've noticed that none of the events were getting fired when called through `dispatch(appRegistryEmit('event-name'))` function. When `appRegistry` is getting saved to state, we are just saving it as `_emitter`. 
- [x] Bugfix

## Open Questions
I can't figure out how to trigger `globalAppRegistry` registration to trigger (does that even happen in this module?), so I am not sure how we are storing it in the state. How did you think it would be stored @imlucas?

## Types of changes
- [x] Patch
