### PR TITLE
check if chunk is array in _write and return a 'malformatted document' error

### DIFF
--- a/src/utils/collection-stream.js
+++ b/src/utils/collection-stream.js
@@ -44,6 +44,12 @@ class WritableCollectionStream extends Writable {
   }
 
   _write(chunk, encoding, next) {
+    if (Array.isArray(chunk)) {
+      const err = new Error('JSON file supplied contains a malformatted document.');
+      this._errors.push(err);
+      return next(err);
+    }
+
     this.batch.insert(chunk);
     if (this.batch.length === this.BATCH_SIZE) {
       // TODO: lucas: expose finer-grained bulk op results:


### PR DESCRIPTION
## Description
Returns an error when `chunk` is an array in `collection-stream` write operation.

## Motivation and Context
Accidentally discovered an error when trying to insert schema instead of actual documents. This error can be reproduced also with something like this:
```
{
    "array1": [{"a": 1}, {"b": 2}, {"c": 3}]
}
```

Driver ends up throwing an Error:
<img width="768" alt="Screen Shot 2019-11-04 at 3 39 09 PM" src="https://user-images.githubusercontent.com/8107784/68138201-74829380-ff28-11e9-8b80-341058446956.png">

For now I am just checking if `chunk` getting inserted through batch operation is an array and returning an error through there. Looks like this:
<img width="726" alt="Screen Shot 2019-11-04 at 4 55 15 PM" src="https://user-images.githubusercontent.com/8107784/68138412-d2af7680-ff28-11e9-83fc-9be4900dbb29.png">

I doubt anyone else will run into this tbh, but just in case!

@sampoonachot while I am on errors here, does this formatting/styling look ok to you? I can adjust if necessary!

- [x] Bugfix

## Open Questions
Should this be detected by `detect-import-file` util??

## Types of changes
- [x] Patch
