### PR TITLE
COMPASS-3961: allow adding missing fields

### DIFF
--- a/src/components/export-field/export-field.less
+++ b/src/components/export-field/export-field.less
@@ -3,6 +3,7 @@
 .export-field {
   &-field-number {
     text-align: center;
+    color: @gray4;
   }
 
 }

--- a/src/components/export-select-fields/export-select-fields.jsx
+++ b/src/components/export-select-fields/export-select-fields.jsx
@@ -25,9 +25,19 @@ class ExportSelectFields extends PureComponent {
     this.newFieldRef = React.createRef();
   }
 
+  state = { addingFields: false }
+
+  componentDidUpdate() {
+    if (this.state.addingFields) {
+      this.newFieldRef.current.scrollIntoView();
+      this.newFieldRef.current.focus();
+    }
+  }
+
   addNewFieldButton = () => {
     this.newFieldRef.current.scrollIntoView();
     this.newFieldRef.current.focus();
+    this.setState({ addingFields: true });
   }
 
   handleFieldCheckboxChange = (evt) => {
@@ -46,6 +56,10 @@ class ExportSelectFields extends PureComponent {
     }
 
     this.props.updateFields(fields);
+  }
+
+  handleInputOnBlur = () => {
+    this.setState({ addingFields: false });
   }
 
   handleAddFieldSubmit = (evt) => {
@@ -87,6 +101,7 @@ class ExportSelectFields extends PureComponent {
           <input type="text"
             ref={this.newFieldRef}
             placeholder="Add field"
+            onBlur={this.handleInputOnBlur}
             className={style('add-field-input')}
             onKeyDown={this.handleAddFieldSubmit}/>
           <div className={style('return-symbol')}>

--- a/src/components/export-select-fields/export-select-fields.jsx
+++ b/src/components/export-select-fields/export-select-fields.jsx
@@ -1,9 +1,11 @@
 import { Tooltip } from 'hadron-react-components';
+import { TextButton } from 'hadron-react-buttons';
 import ExportField from 'components/export-field';
 import styles from './export-select-fields.less';
 import { FIELDS } from 'constants/export-step';
-import createStyler from 'utils/styler.js';
 import React, { PureComponent } from 'react';
+import createStyler from 'utils/styler.js';
+import classnames from 'classnames';
 import PropTypes from 'prop-types';
 
 
@@ -17,6 +19,16 @@ class ExportSelectFields extends PureComponent {
     exportStep: PropTypes.string.isRequired,
     updateFields: PropTypes.func.isRequired,
   };
+
+  constructor(props) {
+    super(props);
+    this.newFieldRef = React.createRef();
+  }
+
+  addNewFieldButton = () => {
+    this.newFieldRef.current.scrollIntoView();
+    this.newFieldRef.current.focus();
+  }
 
   handleFieldCheckboxChange = (evt) => {
     const fields = Object.assign({}, this.props.fields);
@@ -36,6 +48,17 @@ class ExportSelectFields extends PureComponent {
     this.props.updateFields(fields);
   }
 
+  handleAddFieldSubmit = (evt) => {
+    if (evt.key === 'Enter') {
+      const obj = {};
+      obj[evt.target.value] = 1;
+      const fields = Object.assign(obj, this.props.fields);
+
+      this.props.updateFields(fields);
+      this.newFieldRef.current.focus();
+    }
+  }
+
   isEveryFieldChecked() {
     const fields = this.props.fields;
 
@@ -53,8 +76,33 @@ class ExportSelectFields extends PureComponent {
     ));
   }
 
+  renderEmptyField() {
+    const fieldsLen = Object.keys(this.props.fields).length;
+
+    return (
+      <tr key={`new-field ${fieldsLen}`}>
+        <td/>
+        <td className={style('field-number')}>{fieldsLen + 1}</td>
+        <td>
+          <input type="text"
+            ref={this.newFieldRef}
+            placeholder="Add field"
+            className={style('add-field-input')}
+            onKeyDown={this.handleAddFieldSubmit}/>
+          <div className={style('return-symbol')}>
+            <i className="fa fa-level-down fa-rotate-90"/>
+            <p>to add</p>
+          </div>
+        </td>
+      </tr>
+    );
+    // });
+  }
+
   render() {
     if (this.props.exportStep !== FIELDS) return null;
+
+    const addFieldButtonClassname = classnames('btn', 'btn-default', 'btn-xs', style('new-field'));
 
     return (
       <div>
@@ -66,6 +114,10 @@ class ExportSelectFields extends PureComponent {
             <i className="fa fa-info-circle" />
             <Tooltip id="field-tooltip" />
           </div>
+          <TextButton
+            text="+ Add Field"
+            className={addFieldButtonClassname}
+            clickHandler={this.addNewFieldButton}/>
         </div>
         <div className={style('field-wrapper')}>
           <table className={style('table')}>
@@ -84,6 +136,7 @@ class ExportSelectFields extends PureComponent {
             </thead>
             <tbody>
               {this.renderFieldRows()}
+              {this.renderEmptyField()}
             </tbody>
           </table>
         </div>

--- a/src/components/export-select-fields/export-select-fields.less
+++ b/src/components/export-select-fields/export-select-fields.less
@@ -1,8 +1,13 @@
 @import (reference) '~less/compass/_theme.less';
 
 .export-select-fields {
+  &-new-field {
+    float: right;
+  }
+
   &-caption {
     width: 100%;
+    margin-bottom: 5px;
 
     p {
       margin-right: 7px;
@@ -27,6 +32,35 @@
 
   &-field-name {
     width: 100%;
+  }
+
+  &-field-number {
+    text-align: center;
+    color: @gray4;
+  }
+
+  &-add-field-input {
+    border: none !important;
+    width: 85%;
+    &::placeholder {
+      color: @gray4;
+    }
+  }
+
+
+  &-return-symbol {
+    float: right;
+    padding-left: 10px;
+    display: flex;
+    color: @gray4;
+
+    p {
+      margin: 0 0 0 10px;
+    }
+
+    i {
+      font-size: 13px;
+    }
   }
 
   &-table {


### PR DESCRIPTION
## Description
Adds a `+ ADD FIELD` button with an input field in export-fields modal. 

## Motivation and Context
![ev3eSx4mK0](https://user-images.githubusercontent.com/8107784/69640210-46dbc680-105e-11ea-86b1-c249be351046.gif)

`+ ADD FIELD` button scrolls over to the bottom of the table and focuses on the input field to be edited. The field is only saved on `enter`, which is indicated by the text on the side of the table. When the input field is submitted, `fields` props are updated and the component is refreshed. That particular field is saved even after the user goes to `OUTPUT` and comes back to `FIELDS`. 

## Open Questions
Currently once I hit enter to save the currently edited field, I am not able to prevent the modal from scrolling up a bit. This happens because the element is rerendering, so I understand that the state just changed and the focus was lost. Anyone have an idea as to how to get the focus back to the previous state, aka the input field at the bottom after the rerender?

## Types of changes
- [x] Minor (non-breaking change which adds functionality)