### PR TITLE
UX improvements: display doc count, do not display line numbers

### DIFF
--- a/src/components/query-viewer/query-viewer.jsx
+++ b/src/components/query-viewer/query-viewer.jsx
@@ -17,8 +17,9 @@ const OPTIONS = {
   fontSize: 11,
   minLines: 5,
   maxLines: Infinity,
-  showGutter: true,
+  showGutter: false,
   readOnly: true,
+  fixedWidthGutter: false,
   highlightActiveLine: false,
   highlightGutterLine: false,
   useWorker: false

--- a/src/components/query-viewer/query-viewer.less
+++ b/src/components/query-viewer/query-viewer.less
@@ -8,7 +8,7 @@
  */
 .query-viewer {
   position: relative;
-  padding: 10px 0px 10px 0px;
+  padding: 10px;
   overflow: hidden;
   background: #f5f6f7;
   border-left: 2px solid #e4e4e4;


### PR DESCRIPTION
## Description
Displays document count, does not display line numbers in editor, removes editor 80 character gutter line.

### Checklist
- ~New tests and/or benchmarks are included~
- ~Documentation is changed or added~

## Motivation and Context
Currently when opening up the export modal, you don't get to see the current document count with the initial query. It's displayed as `null`. This PR includes a document count on open, and populates that number.

Some folks were confused that the editor in export modal is not editable, so I am removing the lines to hopefully indicate that a bit more.

Also, for aesthetic purposes, removing the gutter line for the editor.

## Types of changes
- [x] Patch (non-breaking change which fixes an issue)