### PR TITLE
4.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mongodb-js/compass-import-export",
-  "version": "4.1.5",
+  "version": "4.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mongodb-js/compass-import-export",
   "productName": "Compass Import/Export",
-  "version": "4.1.5",
+  "version": "4.2.0",
   "apiVersion": "3.0.0",
   "description": "Compass Import/Export Plugin",
   "homepage": "https://github.com/mongodb-js/compass-import-export",


### PR DESCRIPTION
@lrlna A bit of an unconventional PR! 

I'm cutting master so all of your export improvements from the past few days can be upstreamed into compass asap with `@mongodb-js/compass-import-export@^4.2.0`. 

The import type casting stuff in #18 is complex enough that I don't want it blocking so it will go as `5.0.0`. We can keep this `4.x-releases` branch ref around just in case casting performance is a real dud and we want to take another stab at it.