### PR TITLE
refactor(import): Reuse shared components from export

### DIFF
--- a/src/components/import-modal/import-modal.jsx
+++ b/src/components/import-modal/import-modal.jsx
@@ -108,12 +108,6 @@ class ImportModal extends PureComponent {
     this.props.startImport();
   };
 
-  // TODO: lucas: Make COMPLETED, FINISHED_STATUSES
-  // have better names.
-  // COMPLETED = Done and Successful
-  // FINISHED_STATUSES = Done and maybe success|error|canceled
-  // @irina: "maybe call it IMPORT_STATUS ? since technically a cancelled status means it's not finished"
-
   /**
    * Has the import completed successfully?
    * @returns {Boolean}

--- a/src/components/import-options/import-options.jsx
+++ b/src/components/import-options/import-options.jsx
@@ -46,10 +46,6 @@ class ImportOptions extends PureComponent {
   };
 
   render() {
-    /**
-     * TODO: lucas: Reuse `Select File` component shared with export.
-     */
-
     const isCSV = this.props.fileType === FILE_TYPES.CSV;
 
     return (


### PR DESCRIPTION
## Description

- [ ] Reuse `Select File` component shared with export
- [ ] Use hadron-react OptionSelector that we already have styled/evented/etc for options/field types