### PR TITLE
fix(export): Add global app registry emit for import-finished

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,13 @@ See files in the `./test` directory.
 
 ## TODO/Ideas
 
+- [ ] Import: Move away from `state.fields` being array of objects to using all array's of strings. For now, there is some duplication of fields+transforms+excludes we'll come back to and fixup.
+- [ ] import-apply-type-and-projection supports nested dotnotation and only uses `state.importData.transforms`
+- [ ] Import and Export: New Option: If you need to [specify extended-json legacy spec](https://github.com/mongodb/js-bson/pull/339)
+- [ ] Import: bson-csv: support dotnotation expanded from `.` .<bson_type>() caster like [mongoimport does today][mongoimport]
 - [ ] Import: Preview Table: Use highlight.js, mongodb-ace-mode, or something so the text style of the value within a cell matches its destination type
 - [ ] Export: Use electron add to destination file to [recent documents](https://electronjs.org/docs/tutorial/recent-documents)
 - [ ] Import and Export: Show system notification when operation completes. like dropbox screenshot message. toast "XX/XX documents successfully"
-- [ ] Import and Export: New Option: If you need to [specify extended-json legacy spec](https://github.com/mongodb/js-bson/pull/339)
-- [ ] Refactor src/modules/ so import and export reuse a common base
-- [ ] Import: bson-csv: support existing .<bson_type>() caster like [mongoimport does today][mongoimport]
 - [ ] Import: expose finer-grained bulk op results in progress
 - [ ] Import: New Option: drop target collection before import
 - [ ] Import: New Option: define import mode: insert, upsert, merge
@@ -47,6 +48,7 @@ See files in the `./test` directory.
 - [ ] Import: Improve import-size-guesstimator
 - [ ] Import: guess delimiter in `src/utils/detect-import-file.js`
 - [ ] Import and Export: Extract anything from `./src/utils` that could live as standalone modules so other things like say a cli or a different platform could reuse compass' import/export business logic and perf.
+- [ ] Refactor src/modules/ so import and export reuse a common base
 
 ## License
 

--- a/src/components/export-select-output/export-select-output.jsx
+++ b/src/components/export-select-output/export-select-output.jsx
@@ -24,13 +24,6 @@ import {
 const style = createStyler(styles, 'export-select-output');
 
 /**
- * TODO: lucas: When import complete, maybe:
- * 1. hide “cancel” and replace “import” with “done”?
- * 2. "canel" button -> "close" and import becomes "import another"
- * or "view documents"?
- */
-
-/**
  * Progress messages.
  */
 const MESSAGES = {

--- a/src/modules/compass/app-registry.js
+++ b/src/modules/compass/app-registry.js
@@ -9,15 +9,11 @@ export const appRegistryActivated = (appRegistry) => ({
   appRegistry: appRegistry
 });
 
-export const appRegistryEmit = (name, ...args) => {
-  return (dispatch) => {
-    dispatch({
-      type: EMIT,
-      name: name,
-      args: args
-    });
-  };
-};
+export const appRegistryEmit = (name, ...args) => ({
+  type: EMIT,
+  name: name,
+  args: args
+});
 
 const reducer = (state = INITIAL_STATE, action) => {
   if (action.type === ACTIVATED) {

--- a/src/modules/compass/global-app-registry.js
+++ b/src/modules/compass/global-app-registry.js
@@ -47,10 +47,7 @@ const reducer = (state = INITIAL_STATE, action) => {
   }
   if (action.type === GLOBAL_APP_REGISTRY_EMIT) {
     if (state) {
-      // TODO: lucas: Come back and clean up re:
-      // refresh-data not working as side effect
-      // of redux-rx -> regular ducks reducers
-      // and scoped state.
+      // HACK: lucas: https://github.com/mongodb-js/compass-import-export/pulls/23
       state.emit(action.name, ...action.args);
     }
     return state;

--- a/src/modules/export.js
+++ b/src/modules/export.js
@@ -5,7 +5,7 @@ import stream from 'stream';
 import PROCESS_STATUS from 'constants/process-status';
 import EXPORT_STEP from 'constants/export-step';
 import FILE_TYPES from 'constants/file-types';
-import { appRegistryEmit } from 'modules/compass/app-registry';
+import { appRegistryEmit, globalAppRegistryEmit } from 'modules/compass';
 
 import { createReadableCollectionStream } from 'utils/collection-stream';
 
@@ -425,6 +425,28 @@ export const startExport = () => {
         dispatch(onFinished(numDocsToExport));
         dispatch(
           appRegistryEmit(
+            'export-finished',
+            numDocsToExport,
+            exportData.fileType
+          )
+        );
+
+        /**
+         * TODO: lucas: For metrics:
+         *
+         * "resource": "Export",
+         * "action": "completed",
+         * "file_type": "<csv|json_array>",
+         * "num_docs": "<how many docs exported>",
+         * "full_collection": true|false
+         * "filter": true|false,
+         * "projection": true|false,
+         * "skip": true|false,
+         * "limit": true|false,
+         * "fields_selected": true|false
+         */
+        dispatch(
+          globalAppRegistryEmit(
             'export-finished',
             numDocsToExport,
             exportData.fileType

--- a/src/modules/import.js
+++ b/src/modules/import.js
@@ -251,6 +251,19 @@ export const startImport = () => {
         });
         dispatch(onFinished(dest.docsWritten));
         dispatch(appRegistryEmit('import-finished', size, fileType));
+        /**
+         * TODO: lucas: For metrics:
+         *
+         * "resource": "Import",
+         * "action": "completed",
+         * "user_id": "bce2e94b-7e2f-463d-9555-4a6586322cc4",
+         * "created_at": "2017-10-18T19:47:49.085Z",
+         * "metadata": {
+         * "compass_version": "1.21.0",
+         * "file_type": "<csv|json_array|json_lines>",
+         * "num_docs": "<how many docs imported>",
+         * "datatypes_selected": true|false
+         */
         dispatch(globalAppRegistryEmit('import-finished', size, fileType));
       }
     );

--- a/src/modules/import.js
+++ b/src/modules/import.js
@@ -89,7 +89,9 @@ export const INITIAL_STATE = {
   ignoreBlanks: true,
   fields: [],
   values: [],
-  previewLoaded: false
+  previewLoaded: false,
+  exclude: [],
+  transform: []
 };
 
 /**
@@ -174,7 +176,9 @@ export const startImport = () => {
       delimiter,
       ignoreBlanks,
       stopOnErrors,
-      fields
+      fields,
+      exclude,
+      transform
     } = importData;
 
     const source = fs.createReadStream(fileName, 'utf8');
@@ -214,6 +218,30 @@ export const startImport = () => {
     });
 
     debug('executing pipeline');
+    console.time('import:start');
+    console.group('import:start');
+    
+    console.group('Import Options:');
+    console.table({fileName,
+      fileType,
+      fileIsMultilineJSON,
+      size,
+      delimiter,
+      ignoreBlanks,
+      stopOnErrors
+    });
+
+    console.log('Exclude');
+    console.table(exclude);
+    
+    console.log('Transform');
+    console.table(transform);
+
+    console.log('Fields');
+    console.table(fields);
+    console.groupEnd();
+    
+    console.log('Running import...');
 
     dispatch(onStarted(source, dest));
     stream.pipeline(
@@ -226,6 +254,8 @@ export const startImport = () => {
       progress,
       dest,
       function(err) {
+        console.timeEnd('import:start');
+        console.groupEnd('import:start');
         /**
          * Refresh data (docs, aggregations) regardless of whether we have a
          * partial import or full import
@@ -250,7 +280,13 @@ export const startImport = () => {
           fileType
         });
         dispatch(onFinished(dest.docsWritten));
-        dispatch(appRegistryEmit('import-finished', size, fileType));
+        dispatch(appRegistryEmit('import-finished',
+          size,
+          fileType,
+          dest.docsWritten,
+          exclude.length > 0,
+          transform.length > 0
+        ));
         /**
          * TODO: lucas: For metrics:
          *
@@ -262,9 +298,16 @@ export const startImport = () => {
          * "compass_version": "1.21.0",
          * "file_type": "<csv|json_array|json_lines>",
          * "num_docs": "<how many docs imported>",
-         * "datatypes_selected": true|false
+         * "datatypes_selected": true|false -> fields_excluded
+         * "fields_transformed": true|false -> fields_excluded
          */
-        dispatch(globalAppRegistryEmit('import-finished', size, fileType));
+        dispatch(globalAppRegistryEmit('import-finished',
+          size,
+          fileType,
+          dest.docsWritten,
+          exclude.length > 0,
+          transform.length > 0
+        ));
       }
     );
   };
@@ -552,56 +595,28 @@ export const closeImport = () => ({
  */
 // eslint-disable-next-line complexity
 const reducer = (state = INITIAL_STATE, action) => {
-  if (action.type === SET_GUESSTIMATED_TOTAL) {
+  if (action.type === FILE_SELECTED) {
     return {
       ...state,
-      guesstimatedDocsTotal: action.guesstimatedDocsTotal
+      fileName: action.fileName,
+      fileType: action.fileType,
+      fileStats: action.fileStats,
+      fileIsMultilineJSON: action.fileIsMultilineJSON,
+      status: PROCESS_STATUS.UNSPECIFIED,
+      progress: 0,
+      docsWritten: 0,
+      source: undefined,
+      dest: undefined
     };
   }
 
-  if (action.type === SET_DELIMITER) {
+  /**
+   * ## Options
+   */
+  if (action.type === FILE_TYPE_SELECTED) {
     return {
       ...state,
-      delimiter: action.delimiter
-    };
-  }
-
-  if (action.type === TOGGLE_INCLUDE_FIELD) {
-    const newState = {
-      ...state
-    };
-    newState.fields = newState.fields.map((field) => {
-      if (field.path === action.path) {
-        field.checked = !field.checked;
-      }
-      return field;
-    });
-    return newState;
-  }
-
-  if (action.type === SET_FIELD_TYPE) {
-    const newState = {
-      ...state
-    };
-    newState.fields = newState.fields.map((field) => {
-      if (field.path === action.path) {
-        // If a user changes a field type, automatically check it for them
-        // so they don't need an extra click or forget to click it an get frustrated
-        // like I did so many times :)
-        field.checked = true;
-        field.type = action.bsonType;
-      }
-      return field;
-    });
-    return newState;
-  }
-
-  if (action.type === SET_PREVIEW) {
-    return {
-      ...state,
-      values: action.values,
-      fields: action.fields,
-      previewLoaded: true
+      fileType: action.fileType
     };
   }
 
@@ -619,21 +634,76 @@ const reducer = (state = INITIAL_STATE, action) => {
     };
   }
 
-  if (action.type === FILE_SELECTED) {
+  if (action.type === SET_DELIMITER) {
     return {
       ...state,
-      fileName: action.fileName,
-      fileType: action.fileType,
-      fileStats: action.fileStats,
-      fileIsMultilineJSON: action.fileIsMultilineJSON,
-      status: PROCESS_STATUS.UNSPECIFIED,
-      progress: 0,
-      docsWritten: 0,
-      source: undefined,
-      dest: undefined
+      delimiter: action.delimiter
     };
   }
 
+  /**
+   * ## Preview and projection/data type options
+   */
+  if (action.type === SET_PREVIEW) {
+    return {
+      ...state,
+      values: action.values,
+      fields: action.fields,
+      previewLoaded: true,
+      exclude: [],
+      transforms: []
+    };
+  }
+  /**
+   * When checkbox next to a field is checked/unchecked
+   */
+  if (action.type === TOGGLE_INCLUDE_FIELD) {
+    /**
+     * TODO: lucas: Move away from `state.fields` being
+     * array of objects to using all array's of strings.
+     * For now, there is some duplication of fields+transforms+excludes
+     * we'll come back to and fixup.
+     */
+    const newState = {
+      ...state
+    };
+
+    newState.fields = newState.fields.map((field) => {
+      if (field.path === action.path) {
+        field.checked = !field.checked;
+      }
+      return field;
+    });
+
+    newState.exclude = newState.fields.filter(field => !field.checked).map(field => field.path);
+    newState.transform = newState.fields.filter(field => field.checked).map(field => [field.path, field.type]);
+    return newState;
+  }
+  /**
+   * Changing field type from a select dropdown.
+   */
+  if (action.type === SET_FIELD_TYPE) {
+    const newState = {
+      ...state
+    };
+    newState.fields = newState.fields.map((field) => {
+      if (field.path === action.path) {
+        // If a user changes a field type, automatically check it for them
+        // so they don't need an extra click or forget to click it an get frustrated
+        // like I did so many times :)
+        field.checked = true;
+        field.type = action.bsonType;
+      }
+      return field;
+    });
+    newState.exclude = newState.fields.filter(field => !field.checked).map(field => field.path);
+    newState.transform = newState.fields.filter(field => field.checked).map(field => [field.path, field.type]);
+    return newState;
+  }
+
+  /**
+   * ## Status/Progress
+   */
   if (action.type === FAILED) {
     return {
       ...state,
@@ -650,6 +720,13 @@ const reducer = (state = INITIAL_STATE, action) => {
       status: PROCESS_STATUS.STARTED,
       source: action.source,
       dest: action.dest
+    };
+  }
+
+  if (action.type === SET_GUESSTIMATED_TOTAL) {
+    return {
+      ...state,
+      guesstimatedDocsTotal: action.guesstimatedDocsTotal
     };
   }
 
@@ -697,13 +774,6 @@ const reducer = (state = INITIAL_STATE, action) => {
     return {
       ...state,
       isOpen: false
-    };
-  }
-
-  if (action.type === FILE_TYPE_SELECTED) {
-    return {
-      ...state,
-      fileType: action.fileType
     };
   }
   return state;


### PR DESCRIPTION
## Description

Add back `globalAppRegistryEmit` now that it has been located. 

## Motivation and Context

#14 pointed out `refresh-data` not being called. b490f6844bba99306f37e85b99fde8465969d82a figured out that this was due to a mixup in the migration to streams for `4.1.0`. The old rx epic encouraged reducers to modify global state so an existential emit on globalAppRegistry would happen for every appRegistry `emit()`. However, in `>=4.1.0` with no rx, the existential is dropped and `globalAppRegistry` was confounding to locate in the ducks scoped state model. There is definitely a better way to do this than what's in b490f6844bba99306f37e85b99fde8465969d82a today. Longer-term, see open questions below.

For the time being, just closing the loop on #14 and getting this shipped :)

![Screenshot 2019-12-08 16 29 48](https://user-images.githubusercontent.com/23074/70396725-949aec00-19d9-11ea-85c9-fe8b43d16487.png)

Can see in the background the collection has refreshed after the import completes:

![Screenshot 2019-12-08 16 30 17](https://user-images.githubusercontent.com/23074/70396726-949aec00-19d9-11ea-9b6d-eb267d6cf2e8.png)

## Checklist

- [x] New documentation added (linked to this PR)

## Types of Changes

- [x] Patch Bugfix

## Open Questions

Cleaner way to have both of these? I am leaning towards saying we have a `compass` high-level interface that hides appRegistry and impl details so we just say `compass.emit` instead of knowing this existential 2 registries.
