### PR TITLE
COMPASS-3997: Fix import preview handling nested documents and bson

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ See files in the `./test` directory.
 
 ## TODO/Ideas
 
-- [ ] Import: Move away from `state.fields` being array of objects to using all array's of strings. For now, there is some duplication of fields+transforms+excludes we'll come back to and fixup.
-- [ ] import-apply-type-and-projection supports nested dotnotation and only uses `state.importData.transforms`
+- [x] Import: Move away from `state.fields` being array of objects to using all array's of strings. For now, there is some duplication of fields+transforms+excludes we'll come back to and fixup.
+- [x] import-apply-type-and-projection supports nested dotnotation and only uses `state.importData.transforms`
 - [ ] Import and Export: New Option: If you need to [specify extended-json legacy spec](https://github.com/mongodb/js-bson/pull/339)
 - [ ] Import: bson-csv: support dotnotation expanded from `.` .<bson_type>() caster like [mongoimport does today][mongoimport]
 - [ ] Import: Preview Table: Use highlight.js, mongodb-ace-mode, or something so the text style of the value within a cell matches its destination type
 - [ ] Export: Use electron add to destination file to [recent documents](https://electronjs.org/docs/tutorial/recent-documents)
 - [ ] Import and Export: Show system notification when operation completes. like dropbox screenshot message. toast "XX/XX documents successfully"
-- [ ] Import: expose finer-grained bulk op results in progress
+- [ ] Import: expose finer-grained bulk op results in progress -> "View Import Log File"
 - [ ] Import: New Option: drop target collection before import
 - [ ] Import: New Option: define import mode: insert, upsert, merge
 - [ ] Import: New Option: specify a different path for `_id` such as `business_id` in the yelp dataset

--- a/package-lock.json
+++ b/package-lock.json
@@ -10940,17 +10940,16 @@
       "integrity": "sha512-LNRvR4hr/S8cXXkIY5pTgVP7L3tq6LlYWcg9nWBuW7o1NMxKZo6oOVa/6GIekMGI0Iw7uC+HWimMe9u/VAeKqw=="
     },
     "flat": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
-      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+      "version": "github:cipacda/flat#0453680d406afc82a88dbe1fb9816baad87c92af",
+      "from": "github:cipacda/flat",
       "requires": {
-        "is-buffer": "~2.0.3"
+        "is-buffer": "~2.0.4"
       },
       "dependencies": {
         "is-buffer": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "bson": "^4.0.2",
     "csv-parser": "^2.3.1",
     "fast-csv": "^3.4.0",
-    "flat": "^4.1.0",
+    "flat": "cipacda/flat",
     "javascript-stringify": "^1.6.0",
     "lodash.isobjectlike": "^4.0.0",
     "lodash.isplainobject": "^4.0.6",

--- a/src/modules/import.js
+++ b/src/modules/import.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /* eslint-disable valid-jsdoc */
 /**
  * # Import

--- a/src/modules/import.js
+++ b/src/modules/import.js
@@ -134,7 +134,7 @@ export const onStarted = (source, dest) => ({
  * @param {Number} docsWritten
  * @api private
  */
-export const onFinished = (docsWritten) => ({
+export const onFinished = docsWritten => ({
   type: FINISHED,
   docsWritten: docsWritten
 });
@@ -143,7 +143,7 @@ export const onFinished = (docsWritten) => ({
  * @param {Error} error
  * @api private
  */
-export const onError = (error) => ({
+export const onError = error => ({
   type: FAILED,
   error: error
 });
@@ -152,12 +152,16 @@ export const onError = (error) => ({
  * @param {Number} guesstimatedDocsTotal
  * @api private
  */
-export const onGuesstimatedDocsTotal = (guesstimatedDocsTotal) => ({
+export const onGuesstimatedDocsTotal = guesstimatedDocsTotal => ({
   type: SET_GUESSTIMATED_TOTAL,
   guesstimatedDocsTotal: guesstimatedDocsTotal
 });
 
 /**
+ * Sets up a streaming based pipeline to execute the import
+ * and update status/progress.
+ *
+ * All of the exciting bits happen in `../utils/` :)
  * @api public
  */
 export const startImport = () => {
@@ -176,16 +180,28 @@ export const startImport = () => {
       delimiter,
       ignoreBlanks,
       stopOnErrors,
-      fields,
       exclude,
       transform
     } = importData;
 
     const source = fs.createReadStream(fileName, 'utf8');
 
-    /**
-     * TODO: lucas: Support ignoreUndefined as an option to pass to driver?
-     */
+    const stripBOM = stripBomStream();
+
+    const parser = createParser({
+      fileName,
+      fileType,
+      delimiter,
+      fileIsMultilineJSON
+    });
+
+    const removeBlanks = removeBlanksStream(ignoreBlanks);
+
+    const applyTypes = transformProjectedTypesStream({
+      exclude: exclude,
+      transform: transform
+    });
+
     const dest = createCollectionWriteStream(dataService, ns, stopOnErrors);
 
     const progress = createProgressStream(size, function(err, info) {
@@ -204,25 +220,13 @@ export const startImport = () => {
       }
     );
 
-    const stripBOM = stripBomStream();
-
-    const removeBlanks = removeBlanksStream(ignoreBlanks);
-
-    const applyTypes = transformProjectedTypesStream(fields);
-
-    const parser = createParser({
-      fileName,
-      fileType,
-      delimiter,
-      fileIsMultilineJSON
-    });
-
     debug('executing pipeline');
     console.time('import:start');
     console.group('import:start');
-    
+
     console.group('Import Options:');
-    console.table({fileName,
+    console.table({
+      fileName,
       fileType,
       fileIsMultilineJSON,
       size,
@@ -233,14 +237,10 @@ export const startImport = () => {
 
     console.log('Exclude');
     console.table(exclude);
-    
+
     console.log('Transform');
     console.table(transform);
 
-    console.log('Fields');
-    console.table(fields);
-    console.groupEnd();
-    
     console.log('Running import...');
 
     dispatch(onStarted(source, dest));
@@ -261,6 +261,7 @@ export const startImport = () => {
          * partial import or full import
          */
         dispatch(appRegistryEmit('refresh-data'));
+        // TODO: lucas: should be done on both?
         dispatch(globalAppRegistryEmit('refresh-data'));
         /**
          * TODO: lucas: Decorate with a codeframe if not already
@@ -275,32 +276,38 @@ export const startImport = () => {
         }
 
         dispatch(onFinished(dest.docsWritten));
-        
+
         /**
          * TODO: lucas: Deduping emits. @see https://github.com/mongodb-js/compass-import-export/pulls/23
          **/
-        dispatch(appRegistryEmit('import-finished',
-          size,
-          fileType,
-          dest.docsWritten,
-          fileIsMultilineJSON,
-          delimiter,
-          ignoreBlanks,
-          stopOnErrors,
-          exclude.length > 0,
-          transform.length > 0
-        ));
-        dispatch(globalAppRegistryEmit('import-finished',
-          size,
-          fileType,
-          dest.docsWritten,
-          fileIsMultilineJSON,
-          delimiter,
-          ignoreBlanks,
-          stopOnErrors,
-          exclude.length > 0,
-          transform.length > 0
-        ));
+        dispatch(
+          appRegistryEmit(
+            'import-finished',
+            size,
+            fileType,
+            dest.docsWritten,
+            fileIsMultilineJSON,
+            delimiter,
+            ignoreBlanks,
+            stopOnErrors,
+            exclude.length > 0,
+            transform.length > 0
+          )
+        );
+        dispatch(
+          globalAppRegistryEmit(
+            'import-finished',
+            size,
+            fileType,
+            dest.docsWritten,
+            fileIsMultilineJSON,
+            delimiter,
+            ignoreBlanks,
+            stopOnErrors,
+            exclude.length > 0,
+            transform.length > 0
+          )
+        );
       }
     );
   };
@@ -345,7 +352,7 @@ const loadPreviewDocs = (
   delimiter,
   fileIsMultilineJSON
 ) => {
-  return (dispatch) => {
+  return dispatch => {
     debug('loading preview', {
       fileName,
       fileType,
@@ -388,7 +395,7 @@ const loadPreviewDocs = (
  * @param {String} path Dot notation path of the field.
  * @api public
  */
-export const toggleIncludeField = (path) => ({
+export const toggleIncludeField = path => ({
   type: TOGGLE_INCLUDE_FIELD,
   path: path
 });
@@ -420,24 +427,24 @@ export const setFieldType = (path, bsonType) => ({
  * @api public
  * @see utils/detect-import-file.js
  */
-export const selectImportFileName = (fileName) => {
+export const selectImportFileName = fileName => {
   return (dispatch, getState) => {
     let fileStats = {};
     checkFileExists(fileName)
-      .then((exists) => {
+      .then(exists => {
         if (!exists) {
           throw new Error(`File ${fileName} not found`);
         }
         return getFileStats(fileName);
       })
-      .then((stats) => {
+      .then(stats => {
         fileStats = {
           ...stats,
           type: mime.lookup(fileName)
         };
         return promisify(detectImportFile)(fileName);
       })
-      .then((detected) => {
+      .then(detected => {
         dispatch({
           type: FILE_SELECTED,
           fileName: fileName,
@@ -459,7 +466,7 @@ export const selectImportFileName = (fileName) => {
           )
         );
       })
-      .catch((err) => dispatch(onError(err)));
+      .catch(err => dispatch(onError(err)));
   };
 };
 
@@ -469,7 +476,7 @@ export const selectImportFileName = (fileName) => {
  * @param {String} fileType
  * @api public
  */
-export const selectImportFileType = (fileType) => {
+export const selectImportFileType = fileType => {
   return (dispatch, getState) => {
     const {
       previewLoaded,
@@ -498,7 +505,7 @@ export const selectImportFileType = (fileType) => {
  *
  * @api public
  */
-export const setDelimiter = (delimiter) => {
+export const setDelimiter = delimiter => {
   return (dispatch, getState) => {
     const {
       previewLoaded,
@@ -539,7 +546,7 @@ export const setDelimiter = (delimiter) => {
  * @see utils/collection-stream.js
  * @see https://docs.mongodb.com/manual/reference/program/mongoimport/#cmdoption-mongoimport-stoponerror
  */
-export const setStopOnErrors = (stopOnErrors) => ({
+export const setStopOnErrors = stopOnErrors => ({
   type: SET_STOP_ON_ERRORS,
   stopOnErrors: stopOnErrors
 });
@@ -553,7 +560,7 @@ export const setStopOnErrors = (stopOnErrors) => ({
  * @see https://docs.mongodb.com/manual/reference/program/mongoimport/#cmdoption-mongoimport-ignoreblanks
  * @todo lucas: Standardize as `setIgnoreBlanks`?
  */
-export const setIgnoreBlanks = (ignoreBlanks) => ({
+export const setIgnoreBlanks = ignoreBlanks => ({
   type: SET_IGNORE_BLANKS,
   ignoreBlanks: ignoreBlanks
 });
@@ -661,15 +668,19 @@ const reducer = (state = INITIAL_STATE, action) => {
       ...state
     };
 
-    newState.fields = newState.fields.map((field) => {
+    newState.fields = newState.fields.map(field => {
       if (field.path === action.path) {
         field.checked = !field.checked;
       }
       return field;
     });
 
-    newState.exclude = newState.fields.filter(field => !field.checked).map(field => field.path);
-    newState.transform = newState.fields.filter(field => field.checked).map(field => [field.path, field.type]);
+    newState.exclude = newState.fields
+      .filter(field => !field.checked)
+      .map(field => field.path);
+    newState.transform = newState.fields
+      .filter(field => field.checked)
+      .map(field => [field.path, field.type]);
     return newState;
   }
   /**
@@ -679,7 +690,7 @@ const reducer = (state = INITIAL_STATE, action) => {
     const newState = {
       ...state
     };
-    newState.fields = newState.fields.map((field) => {
+    newState.fields = newState.fields.map(field => {
       if (field.path === action.path) {
         // If a user changes a field type, automatically check it for them
         // so they don't need an extra click or forget to click it an get frustrated
@@ -689,8 +700,12 @@ const reducer = (state = INITIAL_STATE, action) => {
       }
       return field;
     });
-    newState.exclude = newState.fields.filter(field => !field.checked).map(field => field.path);
-    newState.transform = newState.fields.filter(field => field.checked).map(field => [field.path, field.type]);
+    newState.exclude = newState.fields
+      .filter(field => !field.checked)
+      .map(field => field.path);
+    newState.transform = newState.fields
+      .filter(field => field.checked)
+      .map(field => [field.path, field.type]);
     return newState;
   }
 

--- a/src/utils/bson-csv.js
+++ b/src/utils/bson-csv.js
@@ -9,19 +9,6 @@
  */
 
 /**
- * TODO: lucas: Incorporate serialization. Start with what mongoimport
- * does: https://github.com/mongodb/mongo-tools-common/blob/master/json/csv_format.go
- */
-
-/**
- * TODO: lucas: If we want to support types via CSV headers
- * for compatibility with mongoimport, that all happens in:
- * https://github.com/mongodb/mongo-tools/blob/master/mongoimport/typed_fields.go
- *
- * And https://www.npmjs.com/package/flat#transformkey can be used to prototype.
- */
-
-/**
  * TODO: lucas: Other types (null, undefined, etc.) and formats
  * (see mongoimport typed headers) later. Could also include:
  * 1. [val 1, val2] -> array
@@ -102,7 +89,7 @@ export default {
   },
   Timestamp: {
     fromString: function(s) {
-      return new bson.Timestamp.fromString(s);
+      return bson.Timestamp.fromString(s);
     }
   },
   Double: {
@@ -122,12 +109,89 @@ export default {
   }
 };
 
+/**
+ * [`Object.prototype.toString.call(value)`, `string type name`]
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toString#Using_toString_to_detect_object_class
+ */
+const TYPE_FOR_TO_STRING = new Map([
+  ['[object Array]', 'Array'],
+  ['[object Object]', 'Object'],
+  ['[object String]', 'String'],
+  ['[object Date]', 'Date'],
+  ['[object Number]', 'Number'],
+  ['[object Function]', 'Function'],
+  ['[object RegExp]', 'RegExp'],
+  ['[object Boolean]', 'Boolean'],
+  ['[object Null]', 'Null'],
+  ['[object Undefined]', 'Undefined']
+]);
+
 export function detectType(value) {
-  if (value === undefined) {
-    return 'Undefined';
-  }
-  if (value === null) {
-    return 'Null';
-  }
-  return /function ([A-Za-z]+)/.exec(value.constructor.toString())[1];
+  return TYPE_FOR_TO_STRING.get(Object.prototype.toString.call(value));
 }
+
+export function getTypeDescriptorForValue(value) {
+  const t = detectType(value);
+  const _bsontype = t === 'Object' && value._bsontype;
+  return {
+    type: _bsontype || t,
+    isBSON: !!_bsontype
+  };
+}
+
+/**
+ * flat.flatten()
+ * HT https://github.com/hughsk/flat/blob/master/index.js
+ * @param {Object} doc
+ * @returns {Object}
+ */
+export const serialize = function(doc) {
+  const delimiter = '.';
+  const output = {};
+  const maxDepth = 1000;
+
+  function step(object, prev, currentDepth = 1) {
+    Object.keys(object).forEach(function(key) {
+      const value = object[key];
+      const { type, isBSON } = getTypeDescriptorForValue(value);
+      const newKey = prev ? prev + delimiter + key : key;
+
+      /**
+       * TODO: lucas: If we want to support types via CSV headers
+       * for compatibility with mongoimport, update `newKey` to include
+       * the magic suffix.
+       * https://github.com/mongodb/mongo-tools/blob/master/mongoimport/typed_fields.go
+       */
+      /**
+       * TODO: lucas: Standardize what mongoimport
+       * does instead of hex string/EJSON: https://github.com/mongodb/mongo-tools-common/blob/master/json/csv_format.go
+       */
+
+      // BSON values
+      if (isBSON) {
+        output[newKey] = value.toString('hex');
+        return;
+      }
+
+      // Embedded arrays
+      if (type === 'Array') {
+        output[newKey] = bson.EJSON.serialize(value);
+        return;
+      }
+
+      // Embedded documents
+      if (
+        type === 'Object' &&
+        Object.keys(value).length &&
+        currentDepth < maxDepth
+      ) {
+        return step(value, newKey, currentDepth + 1);
+      }
+
+      // All other values
+      output[newKey] = value;
+    });
+  }
+  step(doc);
+  return output;
+};

--- a/src/utils/dotnotation.js
+++ b/src/utils/dotnotation.js
@@ -1,7 +1,10 @@
 import { flatten, unflatten } from 'flat';
 import { getTypeDescriptorForValue } from './bson-csv';
 /**
- * TODO: lucas: Some overlap w/ bson-csv but they do 
+ * TODO: lucas: Some overlap w/ bson-csv but they do
+ * have difference! Can't quite name it yet, but something
+ * to sort in the future.
+ */
 
 /**
  * Converts any nested objects into a single depth object with `dotnotation` keys.

--- a/src/utils/dotnotation.js
+++ b/src/utils/dotnotation.js
@@ -1,4 +1,7 @@
 import { flatten, unflatten } from 'flat';
+import { getTypeDescriptorForValue } from './bson-csv';
+/**
+ * TODO: lucas: Some overlap w/ bson-csv but they do 
 
 /**
  * Converts any nested objects into a single depth object with `dotnotation` keys.
@@ -11,10 +14,18 @@ import { flatten, unflatten } from 'flat';
  * @returns {Object}
  */
 export function serialize(obj) {
-  /**
-   * TODO: lucas: bson type support. For now, drop.
-   */
-  return flatten(obj);
+  return flatten(obj, {
+    safe: true, // preserve arrays and their contents
+    /**
+     * @param {any} value
+     * @returns {Boolean}
+     * NOTE: lucas: Trying an existing fork that supports this new option:
+     * https://github.com/hughsk/flat/pull/93
+     */
+    ignoreValue: function(value) {
+      return getTypeDescriptorForValue(value).isBSON;
+    }
+  });
 }
 
 /**

--- a/src/utils/dotnotation.spec.js
+++ b/src/utils/dotnotation.spec.js
@@ -1,0 +1,61 @@
+/* eslint-disable no-var */
+import dotnotation from './dotnotation';
+import { ObjectId } from 'bson';
+
+describe('dotnotation', () => {
+  it('should handle simplest case', () => {
+    var doc = {
+      _id: 'arlo',
+      name: 'Arlo',
+      age: 5,
+      location: {
+        place: 'home',
+        activity: {
+          sleeping: true,
+          is: 'on the couch'
+        }
+      }
+    };
+
+    expect(dotnotation.serialize(doc)).to.deep.equal({
+      _id: 'arlo',
+      name: 'Arlo',
+      age: 5,
+      'location.place': 'home',
+      'location.activity.is': 'on the couch',
+      'location.activity.sleeping': true
+    });
+  });
+
+  it('should handle not recurse into bson types', () => {
+    var oid = new ObjectId('5df51e94e92c7b5b333d6c4f');
+
+    var doc = {
+      _id: oid
+    };
+
+    var res = dotnotation.serialize(doc);
+    expect(res).to.have.keys(['_id']);
+    expect(res).to.deep.equal({
+      _id: oid
+    });
+  });
+
+  it('should handle not recurse into arrays', () => {
+    var doc = {
+      _id: 'compass',
+      locations: ['berlin', 'nyc', 'philadelphia']
+    };
+    var res = dotnotation.serialize(doc);
+    expect(res).to.have.keys(['_id', 'locations']);
+    /**
+     * NOTE: lucas: This may seem silly but convention
+     * for all flatten-ing libraries is to recurse into
+     * arrays like: `'locations.0'` or `locations.[]`.
+     */
+    expect(res).to.deep.equal({
+      _id: 'compass',
+      locations: ['berlin', 'nyc', 'philadelphia']
+    });
+  });
+});

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -8,6 +8,7 @@
 
 import csv from 'fast-csv';
 import { EJSON } from 'bson';
+import { serialize as flatten } from './bson-csv';
 import { Transform } from 'stream';
 
 /**
@@ -37,47 +38,12 @@ export const createJSONFormatter = function({ brackets = true } = {}) {
   });
 };
 
-// HT https://github.com/hughsk/flat/blob/master/index.js
-const formatTabularRow = function(doc, opts = { delimiter: '.' }) {
-  var delimiter = opts.delimiter || '.';
-  var maxDepth = opts.maxDepth;
-  var output = {};
-
-  function step(object, prev, currentDepth = 1) {
-    Object.keys(object).forEach(function(key) {
-      var value = object[key];
-      var isarray = opts.safe && Array.isArray(value);
-      var type = Object.prototype.toString.call(value);
-      var isobject = type === '[object Object]' || type === '[object Array]';
-      var isbson = isobject && value._bsontype;
-
-      var newKey = prev ? prev + delimiter + key : key;
-
-      if (
-        !isarray &&
-        !isbson &&
-        isobject &&
-        Object.keys(value).length &&
-        (!opts.maxDepth || currentDepth < maxDepth)
-      ) {
-        return step(value, newKey, currentDepth + 1);
-      }
-      if (isbson) {
-        value = value.toString('hex');
-      }
-      output[newKey] = value;
-    });
-  }
-  step(doc);
-  return output;
-};
-
 /**
  * @returns {Stream.Transform}
  */
 export const createCSVFormatter = function() {
   return csv.format({
     headers: true,
-    transform: (row) => formatTabularRow(row)
+    transform: row => flatten(row)
   });
 };

--- a/src/utils/import-apply-types-and-projection.spec.js
+++ b/src/utils/import-apply-types-and-projection.spec.js
@@ -1,20 +1,25 @@
-import apply from './import-apply-types-and-projection';
+import apply, {
+  transformProjectedTypesStream
+} from './import-apply-types-and-projection';
 
 describe('import-apply-types-and-projection', () => {
   it('should include all fields by default', () => {
-    const res = apply([{ path: '_id', checked: true, type: 'String' }], {
-      _id: 'arlo'
-    });
+    const res = apply(
+      { exclude: [], transform: {} },
+      {
+        _id: 'arlo'
+      }
+    );
     expect(res).to.deep.equal({
       _id: 'arlo'
     });
   });
   it('should remove an unchecked path', () => {
     const res = apply(
-      [
-        { path: '_id', checked: true, type: 'String' },
-        { path: 'name', checked: false, type: 'String' }
-      ],
+      {
+        exclude: ['name'],
+        transform: {}
+      },
       {
         _id: 'arlo',
         name: 'Arlo'
@@ -27,11 +32,12 @@ describe('import-apply-types-and-projection', () => {
   });
   it('should deserialize strings to selected types', () => {
     const res = apply(
-      [
-        { path: '_id', checked: true, type: 'String' },
-        { path: 'name', checked: true, type: 'String' },
-        { path: 'birthday', checked: true, type: 'Date' }
-      ],
+      {
+        exclude: [],
+        transform: {
+          birthday: 'Date'
+        }
+      },
       {
         _id: 'arlo',
         name: 'Arlo',
@@ -45,23 +51,66 @@ describe('import-apply-types-and-projection', () => {
       birthday: new Date('2014-09-21')
     });
   });
-  it('should handle nested objects');
+  it('should handle nested objects', () => {
+    const doc = {
+      _id: 'arlo',
+      name: 'Arlo',
+      age: '5',
+      location: {
+        place: 'home',
+        activity: {
+          sleeping: 'true',
+          is: 'on the couch'
+        }
+      }
+    };
+
+    const spec = {
+      exclude: [],
+      transform: {
+        age: 'Number',
+        'location.activity.sleeping': 'Boolean'
+      }
+    };
+
+    const res = apply(spec, doc);
+
+    expect(res).to.deep.equal({
+      _id: 'arlo',
+      name: 'Arlo',
+      age: 5,
+      location: {
+        place: 'home',
+        activity: {
+          sleeping: true,
+          is: 'on the couch'
+        }
+      }
+    });
+  });
+  describe('transformProjectedTypesStream', () => {
+    it('should return a passthrough if nothing to actually transform', () => {
+      const res = transformProjectedTypesStream({ exclude: [], transform: {} });
+      expect(res.constructor.name).to.equal('PassThrough');
+    });
+  });
   describe('Weird Cases', () => {
-    it('should throw if non ascii ends up in field paths', () => {
+    it('should handle non ascii in field paths', () => {
       /**
        * NOTE: lucas: Found this weird bug where my apple health data
        * caused failed type conversion bc of a null pointer.
-       * This case makes sure that doesn't happen and is mostly
-       * so I remember to figure out whats happening later.
+       * Resulted in changing the design and now this weird throw
+       * shouldn't happen anymore.
        */
-      const fields = [
-        { path: '﻿type', checked: false, type: 'String' },
-        { path: 'sourceName', checked: true, type: 'String' },
-        { path: 'sourceVersion', checked: true, type: 'Number' },
-        { path: 'creationDate', checked: true, type: 'Date' },
-        { path: 'startDate', checked: true, type: 'Date' },
-        { path: 'endDate', checked: true, type: 'Date' }
-      ];
+      const spec = {
+        exclude: ['﻿type'],
+        transform: {
+          sourceVersion: 'Number',
+          creationDate: 'Date',
+          startDate: 'Date',
+          endDate: 'Date'
+        }
+      };
 
       const data = {
         creationDate: '2016-11-04 06:30:14 -0400',
@@ -73,7 +122,7 @@ describe('import-apply-types-and-projection', () => {
         value: 'HKCategoryValueSleepAnalysisInBed'
       };
 
-      expect(apply.bind(null, fields, data)).to.throw();
+      expect(apply.bind(null, spec, data)).to.not.throw();
     });
   });
 });


### PR DESCRIPTION
## Description

Fixes a bug in the import preview where `_bsontype` would be displayed as a property column if you selected an import source that included bson such as an extended `.json`.

## Motivation and Context

- ☑️  Import: Move away from `state.fields` being array of objects to using all array's of strings. For now, there is some duplication of fields+transforms+excludes we'll come back to and fixup.
- ☑️ import-apply-type-and-projection supports nested dotnotation and only uses `state.importData.transforms`
- Makes code much simpler. Leaving `state.importData.fields` for now as still convenient for column headers in `<importPreview />` and may do some more work there in the future
- import-apply-type-and-projection stream returns a noop `PassThrough` if user has not declared any transforms/exclusions

## Open Questions

- Should we be calling `refresh-data` only on global app registry instead of both?

## Types of Changes

- [x] Patch (small fixes and a perf feat)