### PR TITLE
fix(import): COMPASS-4206: Fix type detection and export formatting.

### DIFF
--- a/src/modules/export.js
+++ b/src/modules/export.js
@@ -13,6 +13,7 @@ const createProgressStream = require('progress-stream');
 
 import { createLogger } from 'utils/logger';
 import { createCSVFormatter, createJSONFormatter } from 'utils/formatters';
+import dotnotation from '../utils/dotnotation';
 
 const debug = createLogger('export');
 
@@ -346,7 +347,9 @@ export const sampleFields = () => {
         return onError(findErr);
       }
 
-      const fields = Object.keys(docs[0]).sort().reduce((obj, field) => {
+      // Use `dotnotation.serialize()` to recurse into documents and
+      // pick up all possible paths.
+      const fields = Object.keys(dotnotation.serialize(docs[0])).sort().reduce((obj, field) => {
         obj[field] = 1;
 
         return obj;

--- a/src/modules/import.js
+++ b/src/modules/import.js
@@ -256,9 +256,7 @@ export const startImport = () => {
       progress,
       dest,
       function(err) {
-        debugger;
         console.timeEnd('import:start');
-        console.groupEnd();
         /**
          * Refresh data (docs, aggregations) regardless of whether we have a
          * partial import or full import
@@ -311,6 +309,8 @@ export const startImport = () => {
             transform.length > 0
           )
         );
+        console.groupEnd();
+        console.groupEnd();
       }
     );
   };

--- a/src/modules/import.spec.js
+++ b/src/modules/import.spec.js
@@ -123,7 +123,7 @@ describe('import [module]', () => {
           //   source: undefined,
           //   dest: undefined
           // };
-          console.log('subscribe touched', { args: arguments, actions: test.store.getActions()});
+          // console.log('subscribe touched', { args: arguments, actions: test.store.getActions()});
           const expected = {
             isOpen: false,
             progress: 0,

--- a/src/utils/dotnotation.spec.js
+++ b/src/utils/dotnotation.spec.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-var */
 import dotnotation from './dotnotation';
-import { ObjectId } from 'bson';
+import { ObjectId, ObjectID } from 'bson';
 
 describe('dotnotation', () => {
   it('should handle simplest case', () => {
@@ -28,7 +28,7 @@ describe('dotnotation', () => {
   });
 
   it('should handle not recurse into bson types', () => {
-    var oid = new ObjectId('5df51e94e92c7b5b333d6c4f');
+    var oid = new ObjectID('5df51e94e92c7b5b333d6c4f');
 
     var doc = {
       _id: oid

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -16,10 +16,6 @@ import { EOL } from 'os';
  * @returns {Stream.Transform}
  */
 export const createJSONFormatter = function({ brackets = true } = {}) {
-  // if (brackets) {
-  //   return JSONStream.stringify(open, sep, close);
-  // }
-
   return new Transform({
     readableObjectMode: false,
     writableObjectMode: true,
@@ -56,6 +52,8 @@ export const createJSONFormatter = function({ brackets = true } = {}) {
 export const createCSVFormatter = function() {
   return csv.format({
     headers: true,
-    transform: row => flatten(row)
+    transform: row => {
+      return flatten(row);
+    }
   });
 };


### PR DESCRIPTION
- fix(import): COMPASS-4206: Make type detection/casting work right when importing/exporting `.json`. a093933

Importing correctly picks up ObjectID, Number, and Date:

![Screenshot 2020-03-19 17 15 49](https://user-images.githubusercontent.com/23074/77115783-5021e200-6a05-11ea-8363-8a99134046df.png)

- fix(export): Pick up nested objects to include in projection f6baf06

```javascript
doc = {
  _id: 'Arlo', 
  location: {
    place: 'home',
    activity: {
       sleeping: true,
       is: 'on the couch'
    }
};
```
Before this would populate the projection as:

- [x] _id
- [x] location

Now you can specify full paths for more control over what is actually returned:

- [x] _id
- [x] location.place
- [x] location.activity.is
- [x] location.activity.sleeping

Use case: (See a 1M line csv imported that is 300 fields wide and you only want 2).


- fix(export): Add tests to make sure csv's have correct headers. df70ff9

Headers should be dotnotation for nested object paths.