### PR TITLE
COMPASS-4298: Show preview only for csv files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+title: Bug Report
+---
+
+<!--- Please note this repository's Issue Tracker is not being watched.
+Issues are instead being tracked in our public Jira project:
+https://jira.mongodb.org/projects/COMPASS/summary
+-->
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Bug Report
+
+#### Current Behavior
+
+<!--- A clear and concise description of the behavior -->
+
+#### Code/Gist
+
+<!--- Any code, gist links, or repo links you have available that would be helpful for debugging -->
+
+#### Expected Behavior/Code
+
+<!--- A clear and concise description of what you expected to happen (or code). -->
+
+#### Environment
+
+<!--
+- node.js / npm versions: [e.g. node v10.3.0 / npm 6.7.1]
+- OS: [e.g. OSX 10.13.4, Windows 10]
+-->
+
+- node.js / npm versions:
+- OS:
+
+#### Possible Solution
+
+<!--- Only if you have suggestions on a fix for the bug -->
+
+#### Additional Context/Screenshots
+
+<!--- Add any other context about the problem here. If applicable, add screenshots to help explain. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,26 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: Feature Request
+---
+
+<!--- Please note this repository's Issue Tracker is not being watched.
+Issues are instead being tracked in our public Jira project:
+https://jira.mongodb.org/projects/COMPASS/summary
+-->
+
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Feature Request
+
+## Detailed Description
+
+<!--- Provide a detailed description of the change or addition you are proposing -->
+
+## Context
+
+<!--- Why is this change important to you? How would you use it? -->
+
+## Possible Implementation
+
+<!--- Optional: suggest an idea for implementing addition or change -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,15 @@
+---
+name: Question
+about: Create a report to help us improve
+title: Question
+---
+
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Question
+
+<!--- Provide your detailed question here -->
+
+## Additional context
+
+<!--- Optional: supply any additional context on what you are trying to do -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+<!-- Ticket number and a general summary of your changes in the Title above -->
+<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->
+
+<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->
+
+## Description
+<!--- Describe your changes in detail -->
+<!--- If applicable, describe (or illustrate) architecture flow -->
+### Checklist
+- [ ] New tests and/or benchmarks are included
+- [ ] Documentation is changed or added
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
+- [ ] Bugfix
+- [ ] New feature
+- [ ] Dependency update
+- [ ] Misc
+
+## Open Questions
+<!--- Any particular areas you'd like reviewers to pay attention to? -->
+
+## Dependents
+<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->
+
+## Types of changes
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] *Backport Needed*
+- [ ] Patch (non-breaking change which fixes an issue)
+- [ ] Minor (non-breaking change which adds functionality)
+- [ ] Major (fix or feature that would cause existing functionality to change)

--- a/src/components/import-modal/import-modal.jsx
+++ b/src/components/import-modal/import-modal.jsx
@@ -12,11 +12,11 @@ import {
   FAILED,
   UNSPECIFIED
 } from 'constants/process-status';
-
 import ProgressBar from 'components/progress-bar';
 import ErrorBox from 'components/error-box';
 import ImportPreview from 'components/import-preview';
 import ImportOptions from 'components/import-options';
+import FILE_TYPES from 'constants/file-types';
 
 import {
   startImport,
@@ -165,6 +165,27 @@ class ImportModal extends PureComponent {
   }
 
   /**
+   * Renders the import preview.
+   *
+   * @returns {React.Component} The component.
+   */
+  renderImportPreview() {
+    const isCSV = this.props.fileType === FILE_TYPES.CSV;
+
+    if (isCSV) {
+      return (
+        <ImportPreview
+          loaded={this.props.previewLoaded}
+          onFieldCheckedChanged={this.props.toggleIncludeField}
+          setFieldType={this.props.setFieldType}
+          values={this.props.values}
+          fields={this.props.fields}
+        />
+      );
+    }
+  }
+
+  /**
    * Render the component.
    *
    * @returns {React.Component} The component.
@@ -189,14 +210,7 @@ class ImportModal extends PureComponent {
             setIgnoreBlanks={this.props.setIgnoreBlanks}
             fileOpenDialog={fileOpenDialog}
           />
-          <ImportPreview
-            loaded={this.props.previewLoaded}
-            onFieldCheckedChanged={this.props.toggleIncludeField}
-            setFieldType={this.props.setFieldType}
-            values={this.props.values}
-            fields={this.props.fields}
-          />
-
+          {this.renderImportPreview()}
           <ProgressBar
             progress={this.props.progress}
             status={this.props.status}

--- a/src/components/import-options/import-options.jsx
+++ b/src/components/import-options/import-options.jsx
@@ -50,7 +50,6 @@ class ImportOptions extends PureComponent {
     /**
      * TODO: lucas: Reuse `Select File` component shared with export.
      */
-
     const isCSV = this.props.fileType === FILE_TYPES.CSV;
 
     return (

--- a/src/components/import-preview/import-preview.spec.js
+++ b/src/components/import-preview/import-preview.spec.js
@@ -38,6 +38,7 @@ describe('ImportPreview [Component]', () => {
       setFieldTypeSpy = null;
     });
   });
+
   describe('no fields', () => {
     let component;
 

--- a/src/components/select-field-type/select-field-type.spec.js
+++ b/src/components/select-field-type/select-field-type.spec.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import SelectFieldType from './';
+
+let onSelectFieldTypeChangedSpy;
+
+describe('SelectFieldType [Component]', () => {
+  let component;
+
+  before(() => {
+    onSelectFieldTypeChangedSpy = sinon.spy();
+    component = mount(
+      <SelectFieldType
+        fileType="csv"
+        selectedType="string"
+        onChange={onSelectFieldTypeChangedSpy}
+      />
+    );
+  });
+
+  it('should render default option', () => {
+    expect(component.find('option[value="default"]')).to.not.be.present();
+  });
+
+  it('should select string value', () => {
+    expect(component.find('select[defaultValue="string"]')).to.be.present();
+  });
+
+  after(() => {
+    component = null;
+    onSelectFieldTypeChangedSpy = null;
+  });
+});

--- a/src/modules/import.js
+++ b/src/modules/import.js
@@ -365,7 +365,7 @@ const loadPreviewDocs = (
      * actually need it.
      */
     const source = fs.createReadStream(fileName, {encoding: 'utf8', end: 20 * 1024});
-    const dest = createPreviewWritable(fileType, delimiter, fileIsMultilineJSON);
+    const dest = createPreviewWritable({fileType, delimiter, fileIsMultilineJSON});
     stream.pipeline(
       source,
       createPeekStream(fileType, delimiter, fileIsMultilineJSON),
@@ -612,7 +612,8 @@ const reducer = (state = INITIAL_STATE, action) => {
       progress: 0,
       docsWritten: 0,
       source: undefined,
-      dest: undefined
+      dest: undefined,
+      fields: []
     };
   }
 
@@ -692,9 +693,10 @@ const reducer = (state = INITIAL_STATE, action) => {
     newState.exclude = newState.fields
       .filter(field => !field.checked)
       .map(field => field.path);
-    
+
     return newState;
   }
+
   /**
    * Changing field type from a select dropdown.
    */
@@ -718,7 +720,7 @@ const reducer = (state = INITIAL_STATE, action) => {
     newState.transform = newState.fields
       .filter(field => field.checked)
       .map(field => [field.path, field.type]);
-      
+
     return newState;
   }
 

--- a/src/modules/import.spec.js
+++ b/src/modules/import.spec.js
@@ -1,25 +1,26 @@
 import reducer, {
-  STARTED,
-  CANCELED,
-  PROGRESS,
-  FINISHED,
-  FAILED,
+  // STARTED,
+  // CANCELED,
+  // PROGRESS,
+  // FINISHED,
+  // FAILED,
   FILE_TYPE_SELECTED,
   selectImportFileType,
-  FILE_SELECTED,
+  // FILE_SELECTED,
   selectImportFileName,
-  OPEN,
-  CLOSE,
-  SET_PREVIEW,
-  SET_DELIMITER,
-  SET_GUESSTIMATED_TOTAL,
-  SET_STOP_ON_ERRORS,
-  SET_IGNORE_BLANKS,
-  TOGGLE_INCLUDE_FIELD,
-  SET_FIELD_TYPE,
+  // OPEN,
+  // CLOSE,
+  // SET_PREVIEW,
+  // SET_DELIMITER,
+  // SET_GUESSTIMATED_TOTAL,
+  // SET_STOP_ON_ERRORS,
+  // SET_IGNORE_BLANKS,
+  // TOGGLE_INCLUDE_FIELD,
+  // SET_FIELD_TYPE,
   INITIAL_STATE
 } from './import';
-import PROCESS_STATUS from 'constants/process-status';
+
+// import PROCESS_STATUS from 'constants/process-status';
 
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
@@ -109,7 +110,7 @@ describe('import [module]', () => {
         'test',
         'docs.json'
       );
-      return new Promise(function(resolve, reject) {
+      return new Promise(function(resolve) {
         // See https://github.com/dmitry-zaets/redux-mock-store/issues/71#issuecomment-369546064
         // redux-mock-store does not update state automatically.
         test.store.subscribe(() => {

--- a/src/utils/bson-csv.spec.js
+++ b/src/utils/bson-csv.spec.js
@@ -1,5 +1,5 @@
 import bsonCSV, { serialize, detectType, getTypeDescriptorForValue } from './bson-csv';
-import { EJSON, ObjectID, Long, BSONRegExp, Double } from 'bson';
+import { EJSON, ObjectID, Long, BSONRegExp } from 'bson';
 
 // TODO: lucas: probably dumb but think about that later.
 
@@ -127,7 +127,6 @@ describe('bson-csv', () => {
         });
       });
     });
-
     describe('Boolean', () => {
       it('should serialize as a string', () => {
         expect(serialize({ value: false })).to.deep.equal({

--- a/src/utils/import-size-guesstimator.js
+++ b/src/utils/import-size-guesstimator.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 import { Transform } from 'stream';
+
 const sizeof = require('object-sizeof');
 
 export default function createImportSizeGuesstimator(
@@ -21,7 +22,9 @@ export default function createImportSizeGuesstimator(
       if (this._done === true) {
         return cb(null, chunk);
       }
+
       this.sizes.push(sizeof(chunk));
+
       /**
        * fs reads files in 64 kb blocks (default highwatermark for createReadStream()
        * So the first time our stream gets data on or after 64 kb,
@@ -34,8 +37,10 @@ export default function createImportSizeGuesstimator(
         this.sizes.length === 1000
       ) {
         this._done = true;
+
         const bytesPerDoc = source.bytesRead / this.sizes.length;
         const estimatedTotalDocs = fileTotalSize / bytesPerDoc;
+
         onGuesstimate(null, estimatedTotalDocs);
 
         console.group('Object Size estimator');
@@ -46,6 +51,7 @@ export default function createImportSizeGuesstimator(
         console.log('js object sizes for docs seen', this.sizes);
         console.groupEnd();
       }
+
       return cb(null, chunk);
     }
   });

--- a/src/utils/import-size-guesstimator.spec.js
+++ b/src/utils/import-size-guesstimator.spec.js
@@ -18,6 +18,7 @@ import { pipeline } from 'stream';
 describe.skip('guesstimator', () => {
   it('should guess', function(done) {
     this.timeout(5000);
+
     const FILE_SIZE = 92782967;
     const fs = require('fs');
     const source = fs.createReadStream(
@@ -27,14 +28,12 @@ describe.skip('guesstimator', () => {
     const guesstimator = createImportSizeGuesstimator(
       source,
       FILE_SIZE,
-      function(err, guess) {
+      (err) => {
         if (err) return done(err);
-
-        console.log('guess is', guess);
       }
     );
-    pipeline(source, parser, guesstimator, function(err) {
-      console.log('done');
+
+    pipeline(source, parser, guesstimator, (err) => {
       return done(err);
     });
   });


### PR DESCRIPTION
<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
- According to the design https://mongodb.invisionapp.com/share/BVNOZB4DYT3#/screens/316135806 and having in mind that json documents can have nested properties that can't be properly presented in the table view we should display import preview only for csv files, and do not display to for json files.
- Add GitHub templates

### Checklist
- [x] New tests and/or benchmarks are included
- [x] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
