### PR TITLE
COMPASS-4352: Error handle failing type casting

### DIFF
--- a/src/components/error-box/error-box.jsx
+++ b/src/components/error-box/error-box.jsx
@@ -23,9 +23,9 @@ const getPrettyErrorMessage = function(err) {
   return new ANSIConverter(ANSI_TO_HTML_OPTIONS).toHtml(err.message);
 };
 
-class ExportModal extends PureComponent {
+class ErrorBox extends PureComponent {
   static propTypes = {
-    error: PropTypes.bool
+    error: PropTypes.object
   };
   render() {
     if (!this.props.error) {
@@ -41,4 +41,4 @@ class ExportModal extends PureComponent {
   }
 }
 
-export default ExportModal;
+export default ErrorBox;

--- a/src/components/error-box/error-box.less
+++ b/src/components/error-box/error-box.less
@@ -4,4 +4,5 @@
   background-color: #d65d33;
   color: #ffffff;
   padding: 10px;
+  overflow-wrap: break-word;
 }

--- a/src/modules/import.js
+++ b/src/modules/import.js
@@ -201,7 +201,6 @@ export const startImport = () => {
       transform,
       ignoreBlanks
     });
-
     const dest = createCollectionWriteStream(dataService, ns, stopOnErrors);
 
     const progress = createProgressStream(size, function(err, info) {

--- a/src/utils/import-apply-types-and-projection.js
+++ b/src/utils/import-apply-types-and-projection.js
@@ -116,8 +116,14 @@ export function transformProjectedTypesStream({ transform = [], exclude = [], re
   return new Transform({
     objectMode: true,
     transform: function(doc, _encoding, cb) {
-      const result = transformProjectedTypes(doc, { transform, exclude, removeBlanks });
-      cb(null, result);
+      try {
+        const result = transformProjectedTypes(doc, { transform, exclude, removeBlanks });
+        cb(null, result);
+        return;
+      } catch (err) {
+        cb(err);
+        return;
+      }
     }
   });
 }

--- a/src/utils/import-apply-types-and-projection.js
+++ b/src/utils/import-apply-types-and-projection.js
@@ -118,11 +118,9 @@ export function transformProjectedTypesStream({ transform = [], exclude = [], re
     transform: function(doc, _encoding, cb) {
       try {
         const result = transformProjectedTypes(doc, { transform, exclude, removeBlanks });
-        cb(null, result);
-        return;
+        return cb(null, result);
       } catch (err) {
-        cb(err);
-        return;
+        return cb(err);
       }
     }
   });

--- a/src/utils/import-apply-types-and-projection.spec.js
+++ b/src/utils/import-apply-types-and-projection.spec.js
@@ -94,6 +94,26 @@ describe('import-apply-types-and-projection', () => {
       });
       expect(res.constructor.name).to.equal('PassThrough');
     });
+    it('should return an error if theres a type cast which fails', (done) => {
+      const src = stream.Readable.from([{
+        _id: 1,
+        stringToCastToDecimal128: 'ME ERROR'
+      }]);
+
+      const transform = transformProjectedTypesStream({
+        transform: [['stringToCastToDecimal128', 'Decimal128']]
+      });
+      const dest = new stream.Writable({
+        objectMode: true,
+        write: function(doc, encoding, next) {
+          return next(null);
+        }
+      });
+      stream.pipeline(src, transform, dest, function(err) {
+        expect(err.message.includes('TypeError: ME ERROR not a valid Decimal128 string'));
+        done();
+      });
+    });
   });
   describe('Weird Cases', () => {
     it('should handle non ascii in field paths', () => {


### PR DESCRIPTION
COMPASS-4352

This PR adds a try catch to our bson type casting in the import pipeline, so when bson type transformations error it doesn't crash compass. Interestingly this only happens on a few kinds of conversions. `String` -> `Decimal128` errors, while `String` -> `Number` does not (It makes `NaN`). This is the current behavior, I don't think we've heard too much on how people feel about it so maybe its not an issue but maybe something we want to address sometime.

![decimal128 saving](https://user-images.githubusercontent.com/1791149/90392753-c21f5580-e08f-11ea-93bd-905c7da55057.gif)


Also did a `overflow-wrap: break-word` on the error box to fix COMPASS-4250:
*before*
<img width="300" alt="Screen Shot 2020-08-17 at 1 59 20 PM" src="https://user-images.githubusercontent.com/1791149/90393911-eed46c80-e091-11ea-8094-1e5b6aea1170.png">
*after*
<img width="300" alt="Screen Shot 2020-08-17 at 1 59 09 PM" src="https://user-images.githubusercontent.com/1791149/90393916-f1cf5d00-e091-11ea-8e9f-1c3977d60955.png">

