### PR TITLE
chore: update bson to 4.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8501,11 +8501,22 @@
       }
     },
     "bson": {
-      "version": "github:addaleax/js-bson#8350a66861c60b6a351ef25b74220db53f261b0d",
-      "from": "github:addaleax/js-bson#after-the-next-bson-release-you-can-just-use-the-npm-package-again",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.2.0.tgz",
+      "integrity": "sha512-c3MlJqdROnCRvDr/+MLfaDvQ7CvGI4p1hKX45/fvgzSwKRdOjsfRug1NJJ8ty5mXCNtUdjJEWzoZWcBQxV4TyA==",
       "requires": {
-        "buffer": "^5.1.0",
-        "long": "^4.0.0"
+        "buffer": "^5.6.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        }
       }
     },
     "buffer": {

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
   "dependencies": {
     "JSONStream": "^1.3.5",
     "ansi-to-html": "^0.6.11",
-    "bson": "github:addaleax/js-bson#after-the-next-bson-release-you-can-just-use-the-npm-package-again",
+    "bson": "^4.2.0",
     "csv-parser": "^2.3.1",
     "fast-csv": "^3.4.0",
     "flat": "cipacda/flat",

--- a/src/utils/bson-csv.js
+++ b/src/utils/bson-csv.js
@@ -19,7 +19,7 @@
  * 2. {foo: bar} => nested object
  * 3. etc.
  */
-import bson from 'bson';
+import { EJSON, Long, ObjectID, BSONRegExp, Binary, Timestamp, Double, Decimal128 } from 'bson';
 
 import { createLogger } from './logger';
 
@@ -71,21 +71,21 @@ const casters = {
         // EJSON being imported
         return s;
       }
-      return new bson.ObjectID(s);
+      return new ObjectID(s);
     }
   },
   Long: {
     fromString: function(s) {
-      if (s instanceof bson.Long) {
+      if (s instanceof Long) {
         // EJSON being imported
         return s;
       }
-      return bson.Long.fromString(s);
+      return Long.fromString(s);
     }
   },
   RegExpr: {
     fromString: function(s) {
-      if (s instanceof bson.BSONRegExp) {
+      if (s instanceof BSONRegExp) {
         // EJSON being imported
         return s;
       }
@@ -94,46 +94,46 @@ const casters = {
       // if (s.startsWith('/')) {
       //   var regexRegex = '/(.*)/([imxlsu]+)$'
       //   var [pattern, options];
-      //   return new bson.BSONRegExp(pattern, options);
+      //   return new BSONRegExp(pattern, options);
       // }
-      return new bson.BSONRegExp(s);
+      return new BSONRegExp(s);
     }
   },
   Binary: {
     fromString: function(s) {
-      if (s instanceof bson.Binary) {
+      if (s instanceof Binary) {
         return s;
       }
-      return new bson.Binary(s, bson.Binary.SUBTYPE_DEFAULT);
+      return new Binary(s, Binary.SUBTYPE_DEFAULT);
     }
   },
   UUID: {
     fromString: function(s) {
-      if (s instanceof bson.Binary) {
+      if (s instanceof Binary) {
         return s;
       }
-      return new bson.Binary(s, bson.Binary.SUBTYPE_UUID);
+      return new Binary(s, Binary.SUBTYPE_UUID);
     }
   },
   MD5: {
     fromString: function(s) {
-      if (s instanceof bson.Binary) {
+      if (s instanceof Binary) {
         return s;
       }
-      return new bson.Binary(s, bson.Binary.SUBTYPE_MD5);
+      return new Binary(s, Binary.SUBTYPE_MD5);
     }
   },
   Timestamp: {
     fromString: function(s) {
-      if (s instanceof bson.Timestamp) {
+      if (s instanceof Timestamp) {
         return s;
       }
-      return bson.Timestamp.fromString(s);
+      return Timestamp.fromString(s);
     }
   },
   Double: {
     fromString: function(s) {
-      return new bson.Double(s);
+      return new Double(s);
     }
   },
   Int32: {
@@ -143,7 +143,7 @@ const casters = {
   },
   Decimal128: {
     fromString: function(s) {
-      return bson.Decimal128.fromString(s);
+      return Decimal128.fromString(s);
     }
   }
 };
@@ -240,7 +240,7 @@ export const serialize = function(doc) {
 
       // Embedded arrays
       if (type === 'Array') {
-        output[newKey] = bson.EJSON.stringify(value, null, null);
+        output[newKey] = EJSON.stringify(value, null, null);
         return;
       }
 
@@ -304,7 +304,7 @@ export const valueToString = function(value) {
 
   // Embedded arrays
   if (type === 'Array') {
-    return bson.EJSON.stringify(value, null, null);
+    return EJSON.stringify(value, null, null);
   }
 
   if (type === 'Date') {

--- a/src/utils/import-apply-types-and-projection.spec.js
+++ b/src/utils/import-apply-types-and-projection.spec.js
@@ -3,7 +3,7 @@ import apply, {
 } from './import-apply-types-and-projection';
 
 import stream from 'stream';
-import bson, { ObjectID } from 'bson';
+import { ObjectID } from 'bson';
 
 describe('import-apply-types-and-projection', () => {
   it('should include all fields by default', () => {
@@ -149,10 +149,10 @@ describe('import-apply-types-and-projection', () => {
   describe('bson', () => {
     it('should preserve an ObjectID to an ObjectID', () => {
       const res = apply({
-        _id: new bson.ObjectID('5e739e27a4c96922d4435c59')
+        _id: new ObjectID('5e739e27a4c96922d4435c59')
       });
       expect(res).to.deep.equal({
-        _id: new bson.ObjectID('5e739e27a4c96922d4435c59')
+        _id: new ObjectID('5e739e27a4c96922d4435c59')
       });
     });
     it('should preserve a Date', () => {


### PR DESCRIPTION
This allows us to remove the one-off fork we did of `bson`. The switch to only using named imports is here because `bson` is a larger release that (most likely unintentionally) broke default imports from TypeScript.

This would close COMPASS-4426

<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [ ] Bugfix
- [ ] New feature
- [x] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
