### PR TITLE
Prefill export filename

### DIFF
--- a/electron/renderer/index.js
+++ b/electron/renderer/index.js
@@ -21,7 +21,7 @@ import 'less/global.less';
 /**
  * Customize data service for your sandbox.
  */
-const NS = 'lucas_apple_health_data.sleep';
+const NS = 'test.sales';
 
 import Connection from 'mongodb-connection-model';
 const connection = new Connection({

--- a/src/components/export-modal/export-modal.jsx
+++ b/src/components/export-modal/export-modal.jsx
@@ -231,6 +231,7 @@ class ExportModal extends PureComponent {
         status={this.props.status}
         fileType={this.props.fileType}
         fileName={this.props.fileName}
+        ns={this.props.ns}
         progress={this.props.progress}
         exportStep={this.props.exportStep}
         startExport={this.props.startExport}

--- a/src/components/export-select-output/export-select-output.jsx
+++ b/src/components/export-select-output/export-select-output.jsx
@@ -1,5 +1,6 @@
 import SelectFileType from 'components/select-file-type';
 import { IconTextButton } from 'hadron-react-buttons';
+import toNS from 'mongodb-ns';
 import fileSaveDialog from 'utils/file-save-dialog';
 import ProgressBar from 'components/progress-bar';
 import { FILETYPE } from 'constants/export-step';
@@ -38,6 +39,7 @@ class ExportSelectOutput extends PureComponent {
     count: PropTypes.number,
     fileType: PropTypes.string,
     fileName: PropTypes.string,
+    ns: PropTypes.string.isRequired,
     status: PropTypes.string.isRequired,
     exportedDocsCount: PropTypes.number,
     progress: PropTypes.number.isRequired,
@@ -65,7 +67,8 @@ class ExportSelectOutput extends PureComponent {
    * Handle choosing a file from the file dialog.
    */
   handleChooseFile = () => {
-    fileSaveDialog(this.props.fileType).then(result => {
+    const fileNamePrefill = toNS(this.props.ns).collection;
+    fileSaveDialog(this.props.fileType, fileNamePrefill).then(result => {
       if (result && result.filePath && !result.canceled) {
         this.props.selectExportFileName(result.filePath);
       }

--- a/src/utils/file-save-dialog.js
+++ b/src/utils/file-save-dialog.js
@@ -4,14 +4,14 @@ export default function fileSaveDialog(fileType, prefillFileName) {
   const filters = [
     {
       name: `${fileType} file`,
-      extensions: [fileType.toLowerCase()],
-      defaultPath: prefillFileName
+      extensions: [fileType.toLowerCase()]
     }
   ];
   const title = `Select ${fileType} target file`;
   const buttonLabel = 'Select';
   return dialog.showSaveDialog(getCurrentWindow(), {
     title,
+    defaultPath: prefillFileName,
     filters,
     buttonLabel
   });

--- a/src/utils/file-save-dialog.js
+++ b/src/utils/file-save-dialog.js
@@ -1,10 +1,11 @@
-export default function fileSaveDialog(fileType) {
+export default function fileSaveDialog(fileType, prefillFileName) {
   const { dialog, getCurrentWindow } = require('electron').remote;
 
   const filters = [
     {
       name: `${fileType} file`,
-      extensions: [fileType.toLowerCase()]
+      extensions: [fileType.toLowerCase()],
+      defaultPath: prefillFileName
     }
   ];
   const title = `Select ${fileType} target file`;

--- a/src/utils/formatters.spec.js
+++ b/src/utils/formatters.spec.js
@@ -65,7 +65,7 @@ describe('formatters', () => {
           // The driver returns bson v1.x objects to us. They don't have a
           // .toExtendedJSON() method, we simulate that.
           class FakeBSON1Binary extends Binary {
-            get toExtendedJSON() { return undefined; };
+            get toExtendedJSON() { return undefined; }
           }
 
           const binary = new Binary(Buffer.from('56391cc226bc4affbe520f67856c09ec'), 4);


### PR DESCRIPTION
This PR makes it so the export output file popup filename is pre-filled with the name of the collection being exported. 

https://github.com/mongodb-js/compass/issues/1934

![autofill collection name on export](https://user-images.githubusercontent.com/1791149/96123071-9c2cfa80-0ef2-11eb-9505-4a51e3e48f4b.gif)
