### PR TITLE
fix(COMPASS-4449): display all fields in coll to be exported

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6064,8 +6064,7 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -6135,7 +6134,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -8125,7 +8123,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.0.tgz",
       "integrity": "sha512-wbgvOpqopSr7uq6fJrLH8EsvYMJf9gzfo2jCsL2eTy75qXPukA4pCgHamOQkZtY5vmfVtjB+P3LNlMHW5CEZXA==",
-      "dev": true,
       "requires": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
@@ -9019,6 +9016,23 @@
       "integrity": "sha512-tgU3fKwzYjiLEQgPMD9Jt+JjHVL9kW93FiIMX/l7rivvOD4/LL0Mf7gda3+4U2KJBloybwgj5KEoQgGRioMiKQ==",
       "dev": true
     },
+    "cli-table": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+      "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
+      "optional": true,
+      "requires": {
+        "colors": "1.0.3"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+          "optional": true
+        }
+      }
+    },
     "cli-table3": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
@@ -9163,8 +9177,7 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "dev": true
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -9205,8 +9218,7 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "color-string": {
       "version": "0.3.0",
@@ -10113,7 +10125,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "dev": true,
       "requires": {
         "ms": "^2.1.1"
       },
@@ -10121,16 +10132,14 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decimal.js": {
       "version": "10.2.0",
@@ -10393,8 +10402,7 @@
     "denque": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
-      "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ==",
-      "dev": true
+      "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
     },
     "depd": {
       "version": "1.1.2",
@@ -11067,8 +11075,7 @@
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
-      "dev": true
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
     },
     "duplexify": {
       "version": "3.7.1",
@@ -12326,8 +12333,7 @@
     "esprima": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-      "dev": true
+      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
     },
     "esquery": {
       "version": "1.0.1",
@@ -12368,7 +12374,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
       "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
-      "dev": true,
       "requires": {
         "duplexer": "^0.1.1",
         "from": "^0.1.7",
@@ -14190,8 +14195,7 @@
     "from": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
-      "dev": true
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
     },
     "from2": {
       "version": "2.3.0",
@@ -14889,8 +14893,7 @@
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-func-name": {
       "version": "2.0.0",
@@ -16479,6 +16482,12 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "optional": true
+    },
     "ip": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
@@ -16676,7 +16685,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true,
       "requires": {
         "number-is-nan": "^1.0.0"
       }
@@ -16929,6 +16937,12 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "isnumber": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isnumber/-/isnumber-1.0.0.tgz",
+      "integrity": "sha1-Dj+XWbWB2Z3YUIbw7Cp0kJz63QE=",
+      "optional": true
     },
     "isobject": {
       "version": "3.0.1",
@@ -17238,7 +17252,6 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
       "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
-      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^2.6.0"
@@ -17932,6 +17945,15 @@
           "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
           "dev": true
         }
+      }
+    },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "optional": true,
+      "requires": {
+        "invert-kv": "^1.0.0"
       }
     },
     "less": {
@@ -18786,8 +18808,7 @@
     "lodash.chunk": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.chunk/-/lodash.chunk-4.2.0.tgz",
-      "integrity": "sha1-ZuXOH3btJ7QwPYxlEujRIW6BBrw=",
-      "dev": true
+      "integrity": "sha1-ZuXOH3btJ7QwPYxlEujRIW6BBrw="
     },
     "lodash.clone": {
       "version": "3.0.3",
@@ -18838,8 +18859,7 @@
     "lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
-      "dev": true
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
     },
     "lodash.difference": {
       "version": "3.2.2",
@@ -19242,8 +19262,7 @@
     "lodash.isfunction": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
-      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
-      "dev": true
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw=="
     },
     "lodash.isinteger": {
       "version": "4.0.4",
@@ -19688,6 +19707,12 @@
         }
       }
     },
+    "lodash.transform": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.transform/-/lodash.transform-4.6.0.tgz",
+      "integrity": "sha1-EjBkIvYzJK7YSD0/ODMrX2cFR6A=",
+      "optional": true
+    },
     "lodash.union": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-3.1.0.tgz",
@@ -19884,8 +19909,7 @@
     "map-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
-      "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=",
-      "dev": true
+      "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg="
     },
     "map-visit": {
       "version": "1.0.0",
@@ -19988,7 +20012,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-      "dev": true,
       "optional": true
     },
     "meow": {
@@ -21190,11 +21213,16 @@
         "node-source-walk": "^4.0.0"
       }
     },
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "optional": true
+    },
     "mongodb": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.5.4.tgz",
       "integrity": "sha512-xGH41Ig4dkSH5ROGezkgDbsgt/v5zbNUwE3TcFsSbDc6Qn3Qil17dhLsESSDDPTiyFDCPJRpfd4887dtsPgKtA==",
-      "dev": true,
       "requires": {
         "bl": "^2.2.0",
         "bson": "^1.1.1",
@@ -21207,8 +21235,7 @@
         "bson": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.3.tgz",
-          "integrity": "sha512-TdiJxMVnodVS7r0BdL42y/pqC9cL2iKynVwA0Ho3qbsQYr428veL3l7BQyuqiw+Q5SqqoT0m4srSY/BlZ9AxXg==",
-          "dev": true
+          "integrity": "sha512-TdiJxMVnodVS7r0BdL42y/pqC9cL2iKynVwA0Ho3qbsQYr428veL3l7BQyuqiw+Q5SqqoT0m4srSY/BlZ9AxXg=="
         }
       }
     },
@@ -21222,7 +21249,6 @@
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/mongodb-collection-sample/-/mongodb-collection-sample-4.5.1.tgz",
       "integrity": "sha512-tUCdRLToheOh2Tn+KVdhYtbLifxCo60+wVMf0zxtbZLKPYbZqQaYmyrYTsEunePNJyxIutBWdayX79VJ/Fb2hg==",
-      "dev": true,
       "requires": {
         "bson": "^4.0.3",
         "debug": "^4.1.1",
@@ -21239,42 +21265,27 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
           "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true,
           "optional": true
         },
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-          "dev": true,
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "optional": true,
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
-          }
-        },
-        "bson": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-4.1.0.tgz",
-          "integrity": "sha512-xwNzRRsK2xmHvHuPESi0zVfgsm4edO47WdulNaShTriunNUMRDOAlKwpJc8zpkOXczIzbxUD7kFzhUGVYoZLDw==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.1.0",
-            "long": "^4.0.0"
           }
         },
         "camelcase": {
           "version": "5.3.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
           "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-          "dev": true,
           "optional": true
         },
         "cliui": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
           "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-          "dev": true,
           "optional": true,
           "requires": {
             "string-width": "^4.2.0",
@@ -21286,7 +21297,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
           "optional": true,
           "requires": {
             "color-name": "~1.1.4"
@@ -21296,14 +21306,12 @@
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
           "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true,
           "optional": true
         },
         "find-up": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
           "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "dev": true,
           "optional": true,
           "requires": {
             "locate-path": "^5.0.0",
@@ -21314,14 +21322,12 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true,
           "optional": true
         },
         "locate-path": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
           "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
           "optional": true,
           "requires": {
             "p-locate": "^4.1.0"
@@ -21331,14 +21337,12 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/mongodb-ns/-/mongodb-ns-2.2.0.tgz",
           "integrity": "sha512-sch/9jd74VjRCmB5U+Fj4WJnkmAtDQgxqJkBInO7zEknXE+lnDEuNBT5/Wp59HMrWUabssGGq08r6Y6F7pkvVA==",
-          "dev": true,
           "optional": true
         },
         "p-limit": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
-          "dev": true,
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "optional": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -21348,7 +21352,6 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
           "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
           "optional": true,
           "requires": {
             "p-limit": "^2.2.0"
@@ -21358,21 +21361,18 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
           "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-          "dev": true,
           "optional": true
         },
         "path-exists": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
           "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-          "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
           "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-          "dev": true,
           "optional": true,
           "requires": {
             "emoji-regex": "^8.0.0",
@@ -21384,7 +21384,6 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
           "optional": true,
           "requires": {
             "ansi-regex": "^5.0.0"
@@ -21394,7 +21393,6 @@
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
           "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-          "dev": true,
           "optional": true,
           "requires": {
             "ansi-styles": "^4.0.0",
@@ -21403,10 +21401,9 @@
           }
         },
         "yargs": {
-          "version": "15.1.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.1.0.tgz",
-          "integrity": "sha512-T39FNN1b6hCW4SOIk1XyTOWxtXdcen0t+XYrysQmChzSipvhBO8Bj0nK1ozAasdk24dNWuMZvr4k24nz+8HHLg==",
-          "dev": true,
+          "version": "15.4.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
           "optional": true,
           "requires": {
             "cliui": "^6.0.0",
@@ -21419,14 +21416,13 @@
             "string-width": "^4.2.0",
             "which-module": "^2.0.0",
             "y18n": "^4.0.0",
-            "yargs-parser": "^16.1.0"
+            "yargs-parser": "^18.1.2"
           }
         },
         "yargs-parser": {
-          "version": "16.1.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
-          "integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
-          "dev": true,
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
           "optional": true,
           "requires": {
             "camelcase": "^5.0.0",
@@ -21491,6 +21487,36 @@
           "resolved": "https://registry.npmjs.org/mongodb-ns/-/mongodb-ns-2.2.0.tgz",
           "integrity": "sha512-sch/9jd74VjRCmB5U+Fj4WJnkmAtDQgxqJkBInO7zEknXE+lnDEuNBT5/Wp59HMrWUabssGGq08r6Y6F7pkvVA==",
           "dev": true
+        }
+      }
+    },
+    "mongodb-extended-json": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/mongodb-extended-json/-/mongodb-extended-json-1.11.0.tgz",
+      "integrity": "sha512-+PLUMH7amvTYumCUR6alR474KmqtlmYeceJjsC+zcfdXls9IotfTp2WIuD6X5tO9dLDVCDqboqjgvXj/JjGj6g==",
+      "optional": true,
+      "requires": {
+        "JSONStream": "^1.1.1",
+        "async": "^3.1.0",
+        "bson": "^1.0.1",
+        "event-stream": "^4.0.1",
+        "lodash.isfunction": "^3.0.6",
+        "lodash.transform": "^4.6.0",
+        "moment": "^2.10.6",
+        "raf": "^3.1.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+          "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
+          "optional": true
+        },
+        "bson": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
+          "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg==",
+          "optional": true
         }
       }
     },
@@ -21981,8 +22007,7 @@
     "mongodb-ns": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mongodb-ns/-/mongodb-ns-2.0.0.tgz",
-      "integrity": "sha1-Zr6eNurW3odBTEYOmhNubQ5sujI=",
-      "dev": true
+      "integrity": "sha1-Zr6eNurW3odBTEYOmhNubQ5sujI="
     },
     "mongodb-reflux-store": {
       "version": "0.0.1",
@@ -22001,6 +22026,101 @@
           "dev": true,
           "requires": {
             "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "mongodb-schema": {
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/mongodb-schema/-/mongodb-schema-8.2.5.tgz",
+      "integrity": "sha512-847OmAJR5s4kUKN/ZxL3GnsddGiCaXXZ7T5b6So3yl+GTwgoTGSryJEAxkCpzaPo5NMxIF606tK16Sumnt6KBg==",
+      "requires": {
+        "async": "^1.5.2",
+        "cli-table": "^0.3.1",
+        "event-stream": "^4.0.1",
+        "js-yaml": "^3.5.2",
+        "lodash": "^3.8.0",
+        "mongodb": "^3.1.4",
+        "mongodb-collection-sample": "^4.4.2",
+        "mongodb-extended-json": "^1.6.2",
+        "mongodb-ns": "^2.0.0",
+        "numeral": "^1.5.3",
+        "progress": "^1.1.8",
+        "reservoir": "^0.1.2",
+        "stats-lite": "^2.0.0",
+        "yargs": "^3.32.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        },
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+          "optional": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "optional": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+          "optional": true,
+          "requires": {
+            "lcid": "^1.0.0"
+          }
+        },
+        "progress": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+          "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74="
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "optional": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          }
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "optional": true
+        },
+        "yargs": {
+          "version": "3.32.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+          "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+          "optional": true,
+          "requires": {
+            "camelcase": "^2.0.1",
+            "cliui": "^3.0.3",
+            "decamelize": "^1.1.1",
+            "os-locale": "^1.4.0",
+            "string-width": "^1.0.1",
+            "window-size": "^0.1.4",
+            "y18n": "^3.2.0"
           }
         }
       }
@@ -22679,14 +22799,12 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "numeral": {
       "version": "1.5.6",
       "resolved": "https://registry.npmjs.org/numeral/-/numeral-1.5.6.tgz",
-      "integrity": "sha1-ODHbloRRuc9q/5v5WSXx7443sz8=",
-      "dev": true
+      "integrity": "sha1-ODHbloRRuc9q/5v5WSXx7443sz8="
     },
     "nwsapi": {
       "version": "2.2.0",
@@ -23937,7 +24055,6 @@
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-      "dev": true,
       "requires": {
         "through": "~2.3"
       }
@@ -23980,8 +24097,7 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "picomatch": {
       "version": "2.2.1",
@@ -26617,7 +26733,6 @@
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
       "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "dev": true,
       "requires": {
         "performance-now": "^2.1.0"
       }
@@ -28290,20 +28405,17 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "require_optional": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
       "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
-      "dev": true,
       "requires": {
         "resolve-from": "^2.0.0",
         "semver": "^5.1.0"
@@ -28312,8 +28424,7 @@
         "resolve-from": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
-          "dev": true
+          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
         }
       }
     },
@@ -28326,8 +28437,7 @@
     "reservoir": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/reservoir/-/reservoir-0.1.2.tgz",
-      "integrity": "sha1-8I6sFWSVEjA5y8XuBvP1iXnkVgU=",
-      "dev": true
+      "integrity": "sha1-8I6sFWSVEjA5y8XuBvP1iXnkVgU="
     },
     "resize-observer-polyfill": {
       "version": "1.5.1",
@@ -28516,7 +28626,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
       "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
-      "dev": true,
       "optional": true,
       "requires": {
         "sparse-bitfield": "^3.0.3"
@@ -28607,8 +28716,7 @@
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "send": {
       "version": "0.17.1",
@@ -28754,8 +28862,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-value": {
       "version": "2.0.1",
@@ -29445,7 +29552,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
-      "dev": true,
       "optional": true,
       "requires": {
         "memory-pager": "^1.0.2"
@@ -29613,7 +29719,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
       "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-      "dev": true,
       "requires": {
         "through": "2"
       }
@@ -29638,8 +29743,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "ssh2": {
       "version": "0.8.8",
@@ -29714,6 +29818,15 @@
         }
       }
     },
+    "stats-lite": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stats-lite/-/stats-lite-2.2.0.tgz",
+      "integrity": "sha512-/Kz55rgUIv2KP2MKphwYT/NCuSfAlbbMRv2ZWw7wyXayu230zdtzhxxuXXcvsc6EmmhS8bSJl3uS1wmMHFumbA==",
+      "optional": true,
+      "requires": {
+        "isnumber": "~1.0.0"
+      }
+    },
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
@@ -29774,7 +29887,6 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
       "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
-      "dev": true,
       "requires": {
         "duplexer": "~0.1.1",
         "through": "~2.3.4"
@@ -29865,7 +29977,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dev": true,
       "requires": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -30272,7 +30383,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -33254,8 +33364,7 @@
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "which-pm-runs": {
       "version": "1.0.0",
@@ -33320,6 +33429,12 @@
           }
         }
       }
+    },
+    "window-size": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
+      "optional": true
     },
     "wordwrap": {
       "version": "1.0.0",
@@ -33481,8 +33596,7 @@
     "y18n": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-      "dev": true
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
     },
     "yallist": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "marky": "^1.2.1",
     "mime-types": "^2.1.24",
     "mongodb-extjson": "^4.0.0-rc1",
+    "mongodb-schema": "^8.2.5",
     "object-sizeof": "^1.5.1",
     "parse-json": "^5.0.0",
     "peek-stream": "^1.1.3",

--- a/src/components/export-select-fields/export-select-fields.jsx
+++ b/src/components/export-select-fields/export-select-fields.jsx
@@ -66,10 +66,13 @@ class ExportSelectFields extends PureComponent {
     if (evt.key === 'Enter') {
       const obj = {};
       obj[evt.target.value] = 1;
-      const fields = Object.assign(obj, this.props.fields);
+      // assign current entry to the end of the fields list
+      const fields = Object.assign({}, this.props.fields, obj);
 
       this.props.updateFields(fields);
-      this.newFieldRef.current.focus();
+      // this will trigger 'componentDidMount()` which focuses on input field to
+      // keep adding missing fields
+      this.setState({ addingFields: true });
     }
   }
 

--- a/src/modules/export.js
+++ b/src/modules/export.js
@@ -14,7 +14,6 @@ const createProgressStream = require('progress-stream');
 
 import { createLogger } from 'utils/logger';
 import { createCSVFormatter, createJSONFormatter } from 'utils/formatters';
-import dotnotation from '../utils/dotnotation';
 
 const debug = createLogger('export');
 
@@ -346,7 +345,7 @@ export const sampleFields = () => {
     const sampleOptions = {
       query: spec.filter,
       size: 100,
-      promoteValues: true 
+      promoteValues: true
     };
 
     // To make sure we have less errors in the fields we generate for export, we

--- a/src/modules/export.js
+++ b/src/modules/export.js
@@ -1,6 +1,7 @@
 /* eslint-disable valid-jsdoc */
 import fs from 'fs';
 import stream from 'stream';
+import { stream as schemaStream } from 'mongodb-schema';
 
 import PROCESS_STATUS from 'constants/process-status';
 import EXPORT_STEP from 'constants/export-step';
@@ -342,20 +343,43 @@ export const sampleFields = () => {
       ? { filter: {} }
       : exportData.query;
 
-    dataService.find(ns, spec.filter, {limit: 1}, function(findErr, docs) {
-      if (findErr) {
-        return onError(findErr);
-      }
+    const sampleOptions = {
+      query: spec.filter,
+      size: 100,
+      promoteValues: true 
+    };
 
-      // Use `dotnotation.serialize()` to recurse into documents and
-      // pick up all possible paths.
-      const fields = Object.keys(dotnotation.serialize(docs[0])).sort().reduce((obj, field) => {
-        obj[field] = 1;
+    // To make sure we have less errors in the fields we generate for export, we
+    // are sampling 100 documents from the current collection and then sending
+    // those documents through mongodb-schema.
+    const samplingStream = dataService.sample(ns, sampleOptions);
+    const analyzingStream = schemaStream();
 
-        return obj;
-      }, {});
+    // Grab all the field paths that mongodb-schema generates for us.
+    const parseSchema = new stream.Transform({
+      writableObjectMode: true,
+      transform(chunk, encoding, callback) {
+        const fields = chunk.fields.reduce((obj, field)=> {
+          if (field.type.includes('Document')) {
+            const doc = field.types.find(type => type.name === 'Document');
+            doc.fields.map((field_) => {
+              obj[field_.path] = 1;
+              return obj;
+            });
+          } else {
+            obj[field.path] = 1;
+          }
 
-      dispatch(updateFields(fields));
+          return obj;
+        }, {});
+
+        dispatch(updateFields(fields));
+        callback(null, fields);
+      },
+    });
+
+    stream.pipeline(samplingStream, analyzingStream, parseSchema, function(samplingErr) {
+      if (samplingErr) return onError(samplingErr);
     });
   };
 };

--- a/src/modules/export.js
+++ b/src/modules/export.js
@@ -19,25 +19,25 @@ const debug = createLogger('export');
 
 const PREFIX = 'import-export/export';
 
-const STARTED = `${PREFIX}/STARTED`;
-const CANCELED = `${PREFIX}/CANCELED`;
+export const STARTED = `${PREFIX}/STARTED`;
+export const CANCELED = `${PREFIX}/CANCELED`;
 
-const PROGRESS = `${PREFIX}/PROGRESS`;
-const FINISHED = `${PREFIX}/FINISHED`;
-const ERROR = `${PREFIX}/ERROR`;
+export const PROGRESS = `${PREFIX}/PROGRESS`;
+export const FINISHED = `${PREFIX}/FINISHED`;
+export const ERROR = `${PREFIX}/ERROR`;
 
-const SELECT_FILE_TYPE = `${PREFIX}/SELECT_FILE_TYPE`;
-const SELECT_FILE_NAME = `${PREFIX}/SELECT_FILE_NAME`;
+export const SELECT_FILE_TYPE = `${PREFIX}/SELECT_FILE_TYPE`;
+export const SELECT_FILE_NAME = `${PREFIX}/SELECT_FILE_NAME`;
 
-const ON_MODAL_OPEN = `${PREFIX}/ON_MODAL_OPEN`;
-const CLOSE = `${PREFIX}/CLOSE`;
+export const ON_MODAL_OPEN = `${PREFIX}/ON_MODAL_OPEN`;
+export const CLOSE = `${PREFIX}/CLOSE`;
 
-const CHANGE_EXPORT_STEP = `${PREFIX}/CHANGE_EXPORT_STEP`;
+export const CHANGE_EXPORT_STEP = `${PREFIX}/CHANGE_EXPORT_STEP`;
 
-const UPDATE_FIELDS = `${PREFIX}/UPDATE_FIELDS`;
+export const UPDATE_FIELDS = `${PREFIX}/UPDATE_FIELDS`;
 
-const QUERY_CHANGED = `${PREFIX}/QUERY_CHANGED`;
-const TOGGLE_FULL_COLLECTION = `${PREFIX}/TOGGLE_FULL_COLLECTION`;
+export const QUERY_CHANGED = `${PREFIX}/QUERY_CHANGED`;
+export const TOGGLE_FULL_COLLECTION = `${PREFIX}/TOGGLE_FULL_COLLECTION`;
 
 /**
  * A full collection query.
@@ -165,7 +165,6 @@ const reducer = (state = INITIAL_STATE, action) => {
     );
     return {
       ...state,
-      // isOpen: !isComplete,
       status: isComplete ? PROCESS_STATUS.COMPLETED : state.status,
       exportedDocsCount: action.exportedDocsCount,
       source: undefined,
@@ -272,7 +271,8 @@ export const queryChanged = query => ({
  */
 export const onModalOpen = (count, query) => ({
   type: ON_MODAL_OPEN,
-  count: count, query: query
+  count: count,
+  query: query
 });
 
 /**

--- a/src/modules/export.js
+++ b/src/modules/export.js
@@ -344,7 +344,7 @@ export const sampleFields = () => {
 
     const sampleOptions = {
       query: spec.filter,
-      size: 100,
+      size: 50,
       promoteValues: true
     };
 


### PR DESCRIPTION
## Description
Fixes two things:
1. All inserted fields in 'Export' are shown in order they're inserted. That is,
the field currently inserted by the user is listed as last instead of as first.

2. Shows all fields to be exported. This introduces two more things:
   - We now sample 100 documents from the current collection to get more
     accurate field information.
   - Those 100 documents are run through `mongodb-schema` to get all field
     paths.

## Open Questions
- Do we want to sample more than 100 documents? Should we sample less?

## Types of changes
- [x] Patch (non-breaking change which fixes an issue)