### PR TITLE
fix: Do not auto-convert string values to boolean COMPASS-4466

### DIFF
--- a/src/utils/bson-csv.js
+++ b/src/utils/bson-csv.js
@@ -20,8 +20,8 @@
  * 3. etc.
  */
 import bson from 'bson';
-
 import { createLogger } from './logger';
+
 
 const debug = createLogger('bson-csv');
 
@@ -249,14 +249,16 @@ export const serialize = function(doc) {
         return;
       }
 
-      if (BOOLEAN_TRUE.includes(value)) {
-        output[newKey] = 'true';
-        return;
-      }
+      if (type === 'Boolean') {
+        if (BOOLEAN_TRUE.includes(value)) {
+          output[newKey] = 'true';
+          return;
+        }
 
-      if (BOOLEAN_FALSE.includes(value)) {
-        output[newKey] = 'false';
-        return;
+        if (BOOLEAN_FALSE.includes(value)) {
+          output[newKey] = 'false';
+          return;
+        }
       }
 
       // Embedded documents

--- a/src/utils/bson-csv.spec.js
+++ b/src/utils/bson-csv.spec.js
@@ -25,9 +25,49 @@ describe('bson-csv', () => {
         expect(bsonCSV.Boolean.fromString('true')).to.equal(true);
         expect(bsonCSV.Boolean.fromString('TRUE')).to.equal(true);
       });
+      it('should serialize as a string', () => {
+        expect(serialize({ value: false })).to.deep.equal({
+          value: 'false'
+        });
+
+        expect(serialize({ value: true })).to.deep.equal({
+          value: 'true'
+        });
+      });
+      it('should not auto-convert other values', () => {
+        expect(serialize({ value: 'false' })).to.deep.equal({
+          value: 'false'
+        });
+        expect(serialize({ value: 'FALSE' })).to.deep.equal({
+          value: 'FALSE'
+        });
+        expect(serialize({ value: 'true' })).to.deep.equal({
+          value: 'true'
+        });
+        expect(serialize({ value: 'TRUE' })).to.deep.equal({
+          value: 'TRUE'
+        });
+        expect(serialize({ value: '0' })).to.deep.equal({
+          value: '0'
+        });
+        expect(serialize({ value: '1' })).to.deep.equal({
+          value: '1'
+        });
+      });
     });
     describe('Number', () => {
-      it('should work', () => {
+      it('should serialize numbers as strings', () => {
+        expect(serialize({ value: 0 })).to.deep.equal({
+          value: '0'
+        });
+        expect(serialize({ value: 1 })).to.deep.equal({
+          value: '1'
+        });
+        expect(serialize({ value: -1.35 })).to.deep.equal({
+          value: '-1.35'
+        });
+      });
+      it('should deserialize numbers from strings', () => {
         expect(bsonCSV.Number.fromString('1')).to.equal(1);
       });
     });
@@ -45,6 +85,27 @@ describe('bson-csv', () => {
           _id: '{47844C7F-544C-8986-E050-A8C063056488}',
           Price: '925000',
           'Date of Transfer': '2017-01-13T00:00:00Z'
+        });
+      });
+      it('should detect value:<Date> as Date', () => {
+        expect(
+          detectType(new Date('2020-03-19T20:02:48.406Z'))
+        ).to.be.equal('Date');
+      });
+      it('should not lose percision', () => {
+        expect(bsonCSV.Date.fromString(new Date('2020-03-19T20:02:48.406Z'))).to.deep.equal(
+          new Date('2020-03-19T20:02:48.406Z')
+        );
+      });
+      it('should serialize as a string', () => {
+        expect(serialize({ value: new BSONRegExp('^mongodb') })).to.deep.equal({
+          value: '/^mongodb/'
+        });
+
+        expect(
+          serialize({ value: new BSONRegExp('^mongodb', 'm') })
+        ).to.deep.equal({
+          value: '/^mongodb/m'
         });
       });
     });
@@ -66,29 +127,6 @@ describe('bson-csv', () => {
       it('should serialize as a string', () => {
         expect(serialize({ value: /^mongodb/ })).to.deep.equal({
           value: '/^mongodb/'
-        });
-      });
-    });
-    describe('Date', () => {
-      it('should detect value:<Date> as Date', () => {
-        expect(
-          detectType(new Date('2020-03-19T20:02:48.406Z'))
-        ).to.be.equal('Date');
-      });
-      it('should not lose percision', () => {
-        expect(bsonCSV.Date.fromString(new Date('2020-03-19T20:02:48.406Z'))).to.deep.equal(
-          new Date('2020-03-19T20:02:48.406Z')
-        );
-      });
-      it('should serialize as a string', () => {
-        expect(serialize({ value: new BSONRegExp('^mongodb') })).to.deep.equal({
-          value: '/^mongodb/'
-        });
-
-        expect(
-          serialize({ value: new BSONRegExp('^mongodb', 'm') })
-        ).to.deep.equal({
-          value: '/^mongodb/m'
         });
       });
     });
@@ -124,25 +162,6 @@ describe('bson-csv', () => {
           name: 'Arlo',
           'location.activity.sleeping': 'true',
           'location.activity.is': 'on the couch'
-        });
-      });
-    });
-    describe('Boolean', () => {
-      it('should serialize as a string', () => {
-        expect(serialize({ value: false })).to.deep.equal({
-          value: 'false'
-        });
-
-        expect(serialize({ value: true })).to.deep.equal({
-          value: 'true'
-        });
-      });
-      it('should serialize as normalized string', () => {
-        expect(serialize({ value: 'FALSE' })).to.deep.equal({
-          value: 'false'
-        });
-        expect(serialize({ value: 'TRUE' })).to.deep.equal({
-          value: 'true'
         });
       });
     });

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -2,10 +2,6 @@
 /* eslint-disable callback-return */
 /* eslint-disable complexity */
 
-/**
- * TODO: lucas: rename `export-formatters`
- */
-
 import csv from 'fast-csv';
 import { EJSON } from 'bson';
 import { serialize as flatten } from './bson-csv';


### PR DESCRIPTION
## Description
In the past Compass automatically converted string values that matched `"0", "1", "false", "true", "FALSE", "TRUE", "", "null", "NULL"` to the boolean `true` or `false` during exporting to CSV.

This conversion is now disabled and the values are exported as they are. Only "real" boolean values will be exported as `true` or `false`. This is in line with the behavior of `mongoexport`.

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
