### PR TITLE
fix: Add mongodb-query-parser and use its stringify COMPASS-4481

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11119,6 +11119,21 @@
       "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==",
       "dev": true
     },
+    "ejson-shell-parser": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ejson-shell-parser/-/ejson-shell-parser-1.0.2.tgz",
+      "integrity": "sha512-cXuXDWSrwsNovV8d1wNDvCifiqsj8vk1EyfusI5pWMTvTSVb195z2GMBQ6bgeoVv0or7yCV6aokLBU2aOIWwog==",
+      "requires": {
+        "acorn": "^7.4.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+        }
+      }
+    },
     "electron": {
       "version": "6.1.7",
       "resolved": "https://registry.npmjs.org/electron/-/electron-6.1.7.tgz",
@@ -16710,6 +16725,11 @@
       "integrity": "sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA==",
       "dev": true
     },
+    "is-json": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-json/-/is-json-2.0.1.tgz",
+      "integrity": "sha1-a+Fm0USCihMdaGiRuYPfYsOUkf8="
+    },
     "is-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.1.tgz",
@@ -19710,8 +19730,7 @@
     "lodash.transform": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.transform/-/lodash.transform-4.6.0.tgz",
-      "integrity": "sha1-EjBkIvYzJK7YSD0/ODMrX2cFR6A=",
-      "optional": true
+      "integrity": "sha1-EjBkIvYzJK7YSD0/ODMrX2cFR6A="
     },
     "lodash.union": {
       "version": "3.1.0",
@@ -21216,8 +21235,7 @@
     "moment": {
       "version": "2.29.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
-      "optional": true
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "mongodb": {
       "version": "3.5.4",
@@ -21511,7 +21529,6 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/mongodb-extended-json/-/mongodb-extended-json-1.11.0.tgz",
       "integrity": "sha512-+PLUMH7amvTYumCUR6alR474KmqtlmYeceJjsC+zcfdXls9IotfTp2WIuD6X5tO9dLDVCDqboqjgvXj/JjGj6g==",
-      "optional": true,
       "requires": {
         "JSONStream": "^1.1.1",
         "async": "^3.1.0",
@@ -21526,14 +21543,12 @@
         "async": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-          "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
-          "optional": true
+          "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
         },
         "bson": {
           "version": "1.1.5",
           "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
-          "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg==",
-          "optional": true
+          "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
         }
       }
     },
@@ -22021,10 +22036,47 @@
         }
       }
     },
+    "mongodb-language-model": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/mongodb-language-model/-/mongodb-language-model-1.6.1.tgz",
+      "integrity": "sha512-hWZ1tZCvZ0YPDIyDhClS6p1RdYJAN2dX8vzAoklWjVlQOEXxjbYEFab6vZ0SgAx+K66bjBh9fp7JTTKiKNLVfA=="
+    },
     "mongodb-ns": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mongodb-ns/-/mongodb-ns-2.0.0.tgz",
       "integrity": "sha1-Zr6eNurW3odBTEYOmhNubQ5sujI="
+    },
+    "mongodb-query-parser": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mongodb-query-parser/-/mongodb-query-parser-2.1.2.tgz",
+      "integrity": "sha512-SxzpbwRQ16AgjzVeALz8+MEDILqGALcGbPj+fHmAfJUiQMfWu8zdMb550sMquwGudbgUTuTdjPctHE7NfYzkOA==",
+      "requires": {
+        "bson": "^4.0.3",
+        "debug": "^4.1.1",
+        "ejson-shell-parser": "^1.0.2",
+        "is-json": "^2.0.1",
+        "javascript-stringify": "^2.0.1",
+        "lodash": "^4.17.15",
+        "lru-cache": "^5.1.1",
+        "mongodb-extended-json": "^1.10.2",
+        "mongodb-language-model": "^1.6.1",
+        "ms": "^2.1.2"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
     },
     "mongodb-reflux-store": {
       "version": "0.0.1",
@@ -33618,8 +33670,7 @@
     "yallist": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.0.tgz",
-      "integrity": "sha512-6gpP93MR+VOOehKbCPchro3wFZNSNmek8A2kbkOAZLIZAYx1KP/zAqwO0sOHi3xJEb+UBz8NaYt/17UNit1Q9w==",
-      "dev": true
+      "integrity": "sha512-6gpP93MR+VOOehKbCPchro3wFZNSNmek8A2kbkOAZLIZAYx1KP/zAqwO0sOHi3xJEb+UBz8NaYt/17UNit1Q9w=="
     },
     "yaml": {
       "version": "1.8.2",

--- a/package.json
+++ b/package.json
@@ -163,6 +163,7 @@
     "marky": "^1.2.1",
     "mime-types": "^2.1.24",
     "mongodb-extjson": "^4.0.0-rc1",
+    "mongodb-query-parser": "^2.1.2",
     "mongodb-schema": "^8.2.5",
     "object-sizeof": "^1.5.1",
     "parse-json": "^5.0.0",

--- a/src/utils/get-shell-js.js
+++ b/src/utils/get-shell-js.js
@@ -1,11 +1,11 @@
-import { stringify as toJavascriptString } from 'javascript-stringify';
+import {stringify} from 'mongodb-query-parser';
 import toNS from 'mongodb-ns';
 
 export default function(ns, spec) {
   let ret = `db.${toNS(ns).collection}.find(\n`;
-  ret += '  ' + toJavascriptString(spec.filter, null, '');
+  ret += '  ' + stringify(spec.filter, '');
   if (spec.project) {
-    ret += ',\n  ' + toJavascriptString(spec.project, null, '');
+    ret += ',\n  ' + stringify(spec.project, '');
   }
   ret += '\n)';
   if (spec.limit) {

--- a/src/utils/get-shell-js.spec.js
+++ b/src/utils/get-shell-js.spec.js
@@ -1,10 +1,18 @@
+import {ObjectId} from 'bson';
 import getShellJS from './get-shell-js';
 
 describe('get-shell-js', () => {
   it('should support simple query', () => {
     const ret = getShellJS('lucas.pets', { filter: { name: 'Arlo' } });
     const expected = `db.pets.find(
-  {name:'Arlo'}
+  {name: 'Arlo'}
+)`;
+    expect(ret).to.equal(expected);
+  });
+  it('should support simple ObjectId', () => {
+    const ret = getShellJS('lucas.pets', { filter: { _id: new ObjectId('deadbeefdeadbeefdeadbeef') } });
+    const expected = `db.pets.find(
+  {_id: ObjectId('deadbeefdeadbeefdeadbeef')}
 )`;
     expect(ret).to.equal(expected);
   });
@@ -14,8 +22,8 @@ describe('get-shell-js', () => {
       project: { name: 1 }
     });
     const expected = `db.pets.find(
-  {name:'Arlo'},
-  {name:1}
+  {name: 'Arlo'},
+  {name: 1}
 )`;
     expect(ret).to.equal(expected);
   });
@@ -26,8 +34,8 @@ describe('get-shell-js', () => {
       limit: 100
     });
     const expected = `db.pets.find(
-  {name:'Arlo'},
-  {name:1}
+  {name: 'Arlo'},
+  {name: 1}
 ).limit(100)`;
 
     expect(ret).to.equal(expected);
@@ -40,8 +48,8 @@ describe('get-shell-js', () => {
       skip: 1
     });
     const expected = `db.pets.find(
-  {name:'Arlo'},
-  {name:1}
+  {name: 'Arlo'},
+  {name: 1}
 ).limit(100).skip(1)`;
 
     expect(ret).to.equal(expected);


### PR DESCRIPTION
## Description
This adds a dependency to https://github.com/mongodb-js/query-parser/ to be able to use its `stringify` method that prints a query correctly including BSON types.

![image](https://user-images.githubusercontent.com/4354632/100900149-d19d9f80-34c2-11eb-916b-d5311f9a57cb.png)

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Types of changes
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
