### PR TITLE
fix: use find to infer fields COMPASS-4154

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -12,7 +12,8 @@
         "syntax-object-rest-spread",
         "transform-object-rest-spread",
         "transform-class-properties",
-        "syntax-dynamic-import"
+        "syntax-dynamic-import",
+        ["transform-runtime", { "regenerator": true }]
       ]
     }
   },
@@ -25,6 +26,7 @@
     "syntax-object-rest-spread",
     "transform-object-rest-spread",
     "transform-class-properties",
-    "syntax-dynamic-import"
+    "syntax-dynamic-import",
+    ["transform-runtime", { "regenerator": true }]
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7739,6 +7739,15 @@
         "babel-helper-evaluate-path": "^0.2.0"
       }
     },
+    "babel-plugin-transform-runtime": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
+      "integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
     "babel-plugin-transform-simplify-comparison-operators": {
       "version": "6.9.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.9.4.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6064,7 +6064,8 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -6134,6 +6135,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -8123,6 +8125,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.0.tgz",
       "integrity": "sha512-wbgvOpqopSr7uq6fJrLH8EsvYMJf9gzfo2jCsL2eTy75qXPukA4pCgHamOQkZtY5vmfVtjB+P3LNlMHW5CEZXA==",
+      "dev": true,
       "requires": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
@@ -9016,23 +9019,6 @@
       "integrity": "sha512-tgU3fKwzYjiLEQgPMD9Jt+JjHVL9kW93FiIMX/l7rivvOD4/LL0Mf7gda3+4U2KJBloybwgj5KEoQgGRioMiKQ==",
       "dev": true
     },
-    "cli-table": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-      "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
-      "optional": true,
-      "requires": {
-        "colors": "1.0.3"
-      },
-      "dependencies": {
-        "colors": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
-          "optional": true
-        }
-      }
-    },
     "cli-table3": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
@@ -9177,7 +9163,8 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -9218,7 +9205,8 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "color-string": {
       "version": "0.3.0",
@@ -10139,7 +10127,8 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
     },
     "decimal.js": {
       "version": "10.2.0",
@@ -10402,7 +10391,8 @@
     "denque": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
-      "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
+      "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ==",
+      "dev": true
     },
     "depd": {
       "version": "1.1.2",
@@ -12348,7 +12338,8 @@
     "esprima": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+      "dev": true
     },
     "esquery": {
       "version": "1.0.1",
@@ -14908,7 +14899,8 @@
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
     },
     "get-func-name": {
       "version": "2.0.0",
@@ -16497,12 +16489,6 @@
         "loose-envify": "^1.0.0"
       }
     },
-    "invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-      "optional": true
-    },
     "ip": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
@@ -16700,6 +16686,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
       "requires": {
         "number-is-nan": "^1.0.0"
       }
@@ -16957,12 +16944,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
-    },
-    "isnumber": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isnumber/-/isnumber-1.0.0.tgz",
-      "integrity": "sha1-Dj+XWbWB2Z3YUIbw7Cp0kJz63QE=",
-      "optional": true
     },
     "isobject": {
       "version": "3.0.1",
@@ -17272,6 +17253,7 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
       "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
+      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^2.6.0"
@@ -17965,15 +17947,6 @@
           "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
           "dev": true
         }
-      }
-    },
-    "lcid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "optional": true,
-      "requires": {
-        "invert-kv": "^1.0.0"
       }
     },
     "less": {
@@ -18828,7 +18801,8 @@
     "lodash.chunk": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.chunk/-/lodash.chunk-4.2.0.tgz",
-      "integrity": "sha1-ZuXOH3btJ7QwPYxlEujRIW6BBrw="
+      "integrity": "sha1-ZuXOH3btJ7QwPYxlEujRIW6BBrw=",
+      "dev": true
     },
     "lodash.clone": {
       "version": "3.0.3",
@@ -18879,7 +18853,8 @@
     "lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
+      "dev": true
     },
     "lodash.difference": {
       "version": "3.2.2",
@@ -20031,6 +20006,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "dev": true,
       "optional": true
     },
     "meow": {
@@ -21241,6 +21217,7 @@
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.5.4.tgz",
       "integrity": "sha512-xGH41Ig4dkSH5ROGezkgDbsgt/v5zbNUwE3TcFsSbDc6Qn3Qil17dhLsESSDDPTiyFDCPJRpfd4887dtsPgKtA==",
+      "dev": true,
       "requires": {
         "bl": "^2.2.0",
         "bson": "^1.1.1",
@@ -21253,7 +21230,8 @@
         "bson": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.3.tgz",
-          "integrity": "sha512-TdiJxMVnodVS7r0BdL42y/pqC9cL2iKynVwA0Ho3qbsQYr428veL3l7BQyuqiw+Q5SqqoT0m4srSY/BlZ9AxXg=="
+          "integrity": "sha512-TdiJxMVnodVS7r0BdL42y/pqC9cL2iKynVwA0Ho3qbsQYr428veL3l7BQyuqiw+Q5SqqoT0m4srSY/BlZ9AxXg==",
+          "dev": true
         }
       }
     },
@@ -21267,6 +21245,7 @@
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/mongodb-collection-sample/-/mongodb-collection-sample-4.5.1.tgz",
       "integrity": "sha512-tUCdRLToheOh2Tn+KVdhYtbLifxCo60+wVMf0zxtbZLKPYbZqQaYmyrYTsEunePNJyxIutBWdayX79VJ/Fb2hg==",
+      "dev": true,
       "requires": {
         "bson": "^4.0.3",
         "debug": "^4.1.1",
@@ -21283,12 +21262,14 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
           "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true,
           "optional": true
         },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
           "optional": true,
           "requires": {
             "color-convert": "^2.0.1"
@@ -21298,6 +21279,7 @@
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/bson/-/bson-4.2.0.tgz",
           "integrity": "sha512-c3MlJqdROnCRvDr/+MLfaDvQ7CvGI4p1hKX45/fvgzSwKRdOjsfRug1NJJ8ty5mXCNtUdjJEWzoZWcBQxV4TyA==",
+          "dev": true,
           "requires": {
             "buffer": "^5.6.0"
           }
@@ -21306,6 +21288,7 @@
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
           "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "dev": true,
           "requires": {
             "base64-js": "^1.3.1",
             "ieee754": "^1.1.13"
@@ -21315,12 +21298,14 @@
           "version": "5.3.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
           "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true,
           "optional": true
         },
         "cliui": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
           "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "dev": true,
           "optional": true,
           "requires": {
             "string-width": "^4.2.0",
@@ -21332,6 +21317,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
           "optional": true,
           "requires": {
             "color-name": "~1.1.4"
@@ -21341,12 +21327,14 @@
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
           "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true,
           "optional": true
         },
         "find-up": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
           "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
           "optional": true,
           "requires": {
             "locate-path": "^5.0.0",
@@ -21357,12 +21345,14 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true,
           "optional": true
         },
         "locate-path": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
           "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
           "optional": true,
           "requires": {
             "p-locate": "^4.1.0"
@@ -21372,12 +21362,14 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/mongodb-ns/-/mongodb-ns-2.2.0.tgz",
           "integrity": "sha512-sch/9jd74VjRCmB5U+Fj4WJnkmAtDQgxqJkBInO7zEknXE+lnDEuNBT5/Wp59HMrWUabssGGq08r6Y6F7pkvVA==",
+          "dev": true,
           "optional": true
         },
         "p-limit": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
           "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
           "optional": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -21387,6 +21379,7 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
           "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
           "optional": true,
           "requires": {
             "p-limit": "^2.2.0"
@@ -21396,18 +21389,21 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
           "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true,
           "optional": true
         },
         "path-exists": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
           "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
           "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
           "optional": true,
           "requires": {
             "emoji-regex": "^8.0.0",
@@ -21419,6 +21415,7 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
           "optional": true,
           "requires": {
             "ansi-regex": "^5.0.0"
@@ -21428,6 +21425,7 @@
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
           "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
           "optional": true,
           "requires": {
             "ansi-styles": "^4.0.0",
@@ -21439,6 +21437,7 @@
           "version": "15.4.1",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
           "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+          "dev": true,
           "optional": true,
           "requires": {
             "cliui": "^6.0.0",
@@ -21458,6 +21457,7 @@
           "version": "18.1.3",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
           "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "dev": true,
           "optional": true,
           "requires": {
             "camelcase": "^5.0.0",
@@ -22044,7 +22044,8 @@
     "mongodb-ns": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mongodb-ns/-/mongodb-ns-2.0.0.tgz",
-      "integrity": "sha1-Zr6eNurW3odBTEYOmhNubQ5sujI="
+      "integrity": "sha1-Zr6eNurW3odBTEYOmhNubQ5sujI=",
+      "dev": true
     },
     "mongodb-query-parser": {
       "version": "2.1.2",
@@ -22063,6 +22064,23 @@
         "ms": "^2.1.2"
       },
       "dependencies": {
+        "bson": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-4.2.2.tgz",
+          "integrity": "sha512-9fX257PVHAUpiRGmY3356RVWKQxLA73BgjA/x5MGuJkTEMeG7yzjuBrsiFB67EXRJnFVKrbJY9t/M+oElKYktQ==",
+          "requires": {
+            "buffer": "^5.6.0"
+          }
+        },
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        },
         "lru-cache": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -22095,101 +22113,6 @@
           "dev": true,
           "requires": {
             "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "mongodb-schema": {
-      "version": "8.2.5",
-      "resolved": "https://registry.npmjs.org/mongodb-schema/-/mongodb-schema-8.2.5.tgz",
-      "integrity": "sha512-847OmAJR5s4kUKN/ZxL3GnsddGiCaXXZ7T5b6So3yl+GTwgoTGSryJEAxkCpzaPo5NMxIF606tK16Sumnt6KBg==",
-      "requires": {
-        "async": "^1.5.2",
-        "cli-table": "^0.3.1",
-        "event-stream": "^4.0.1",
-        "js-yaml": "^3.5.2",
-        "lodash": "^3.8.0",
-        "mongodb": "^3.1.4",
-        "mongodb-collection-sample": "^4.4.2",
-        "mongodb-extended-json": "^1.6.2",
-        "mongodb-ns": "^2.0.0",
-        "numeral": "^1.5.3",
-        "progress": "^1.1.8",
-        "reservoir": "^0.1.2",
-        "stats-lite": "^2.0.0",
-        "yargs": "^3.32.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-        },
-        "camelcase": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-          "optional": true
-        },
-        "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "optional": true,
-          "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
-          }
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-        },
-        "os-locale": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-          "optional": true,
-          "requires": {
-            "lcid": "^1.0.0"
-          }
-        },
-        "progress": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-          "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74="
-        },
-        "wrap-ansi": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-          "optional": true,
-          "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1"
-          }
-        },
-        "y18n": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-          "optional": true
-        },
-        "yargs": {
-          "version": "3.32.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-          "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
-          "optional": true,
-          "requires": {
-            "camelcase": "^2.0.1",
-            "cliui": "^3.0.3",
-            "decamelize": "^1.1.1",
-            "os-locale": "^1.4.0",
-            "string-width": "^1.0.1",
-            "window-size": "^0.1.4",
-            "y18n": "^3.2.0"
           }
         }
       }
@@ -22868,12 +22791,14 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
     },
     "numeral": {
       "version": "1.5.6",
       "resolved": "https://registry.npmjs.org/numeral/-/numeral-1.5.6.tgz",
-      "integrity": "sha1-ODHbloRRuc9q/5v5WSXx7443sz8="
+      "integrity": "sha1-ODHbloRRuc9q/5v5WSXx7443sz8=",
+      "dev": true
     },
     "nwsapi": {
       "version": "2.2.0",
@@ -28474,17 +28399,20 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
     },
     "require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
     },
     "require_optional": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
       "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+      "dev": true,
       "requires": {
         "resolve-from": "^2.0.0",
         "semver": "^5.1.0"
@@ -28493,7 +28421,8 @@
         "resolve-from": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+          "dev": true
         }
       }
     },
@@ -28506,7 +28435,8 @@
     "reservoir": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/reservoir/-/reservoir-0.1.2.tgz",
-      "integrity": "sha1-8I6sFWSVEjA5y8XuBvP1iXnkVgU="
+      "integrity": "sha1-8I6sFWSVEjA5y8XuBvP1iXnkVgU=",
+      "dev": true
     },
     "resize-observer-polyfill": {
       "version": "1.5.1",
@@ -28695,6 +28625,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
       "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "dev": true,
       "optional": true,
       "requires": {
         "sparse-bitfield": "^3.0.3"
@@ -28785,7 +28716,8 @@
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true
     },
     "send": {
       "version": "0.17.1",
@@ -28931,7 +28863,8 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
     },
     "set-value": {
       "version": "2.0.1",
@@ -29621,6 +29554,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+      "dev": true,
       "optional": true,
       "requires": {
         "memory-pager": "^1.0.2"
@@ -29812,7 +29746,8 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "ssh2": {
       "version": "0.8.8",
@@ -29885,15 +29820,6 @@
             "is-descriptor": "^0.1.0"
           }
         }
-      }
-    },
-    "stats-lite": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/stats-lite/-/stats-lite-2.2.0.tgz",
-      "integrity": "sha512-/Kz55rgUIv2KP2MKphwYT/NCuSfAlbbMRv2ZWw7wyXayu230zdtzhxxuXXcvsc6EmmhS8bSJl3uS1wmMHFumbA==",
-      "optional": true,
-      "requires": {
-        "isnumber": "~1.0.0"
       }
     },
     "statuses": {
@@ -30046,6 +29972,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
       "requires": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -30452,6 +30379,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -33433,7 +33361,8 @@
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
     },
     "which-pm-runs": {
       "version": "1.0.0",
@@ -33498,12 +33427,6 @@
           }
         }
       }
-    },
-    "window-size": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
-      "optional": true
     },
     "wordwrap": {
       "version": "1.0.0",
@@ -33665,7 +33588,8 @@
     "y18n": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "dev": true
     },
     "yallist": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -164,7 +164,6 @@
     "mime-types": "^2.1.24",
     "mongodb-extjson": "^4.0.0-rc1",
     "mongodb-query-parser": "^2.1.2",
-    "mongodb-schema": "^8.2.5",
     "object-sizeof": "^1.5.1",
     "parse-json": "^5.0.0",
     "peek-stream": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.7.0",
     "babel-preset-minify": "^0.2.0",
     "babel-preset-react": "^6.24.1",

--- a/src/modules/export.js
+++ b/src/modules/export.js
@@ -346,11 +346,13 @@ export const sampleFields = () => {
       const fields = await loadFields(
         dataService,
         ns,
-        spec.filter,
-        { limit: 50 }
+        {
+          filter: spec.filter,
+          sampleSize: 50,
+          maxDepth: 2
+        }
       );
 
-      console.log('*** fields', fields);
       dispatch(updateFields(fields));
     } catch (err) {
       // ignoring the error here so users can still insert
@@ -391,7 +393,6 @@ export const startExport = () => {
       }
 
       debug('count says to expect %d docs in export', numDocsToExport);
-
       const source = createReadableCollectionStream(dataService, ns, spec, projection);
 
       const progress = createProgressStream({

--- a/src/modules/export.js
+++ b/src/modules/export.js
@@ -1,7 +1,6 @@
 /* eslint-disable valid-jsdoc */
 import fs from 'fs';
 import stream from 'stream';
-import { stream as schemaStream } from 'mongodb-schema';
 
 import PROCESS_STATUS from 'constants/process-status';
 import EXPORT_STEP from 'constants/export-step';
@@ -14,6 +13,7 @@ const createProgressStream = require('progress-stream');
 
 import { createLogger } from 'utils/logger';
 import { createCSVFormatter, createJSONFormatter } from 'utils/formatters';
+import loadFields from './load-fields';
 
 const debug = createLogger('export');
 
@@ -331,7 +331,7 @@ export const openExport = () => {
 };
 
 export const sampleFields = () => {
-  return (dispatch, getState) => {
+  return async(dispatch, getState) => {
     const {
       ns,
       exportData,
@@ -342,44 +342,21 @@ export const sampleFields = () => {
       ? { filter: {} }
       : exportData.query;
 
-    const sampleOptions = {
-      query: spec.filter,
-      size: 50,
-      promoteValues: true
-    };
+    try {
+      const fields = await loadFields(
+        dataService,
+        ns,
+        spec.filter,
+        { limit: 50 }
+      );
 
-    // To make sure we have less errors in the fields we generate for export, we
-    // are sampling 100 documents from the current collection and then sending
-    // those documents through mongodb-schema.
-    const samplingStream = dataService.sample(ns, sampleOptions);
-    const analyzingStream = schemaStream();
-
-    // Grab all the field paths that mongodb-schema generates for us.
-    const parseSchema = new stream.Transform({
-      writableObjectMode: true,
-      transform(chunk, encoding, callback) {
-        const fields = chunk.fields.reduce((obj, field)=> {
-          if (field.type.includes('Document')) {
-            const doc = field.types.find(type => type.name === 'Document');
-            doc.fields.map((field_) => {
-              obj[field_.path] = 1;
-              return obj;
-            });
-          } else {
-            obj[field.path] = 1;
-          }
-
-          return obj;
-        }, {});
-
-        dispatch(updateFields(fields));
-        callback(null, fields);
-      },
-    });
-
-    stream.pipeline(samplingStream, analyzingStream, parseSchema, function(samplingErr) {
-      if (samplingErr) return onError(samplingErr);
-    });
+      console.log('*** fields', fields);
+      dispatch(updateFields(fields));
+    } catch (err) {
+      // ignoring the error here so users can still insert
+      // fields manually
+      debug('failed to load fields', err);
+    }
   };
 };
 

--- a/src/modules/load-fields.js
+++ b/src/modules/load-fields.js
@@ -2,29 +2,47 @@ import util from 'util';
 import dotnotation from '../utils/dotnotation';
 
 const DEFAULT_SAMPLE_SIZE = 50;
+const ENABLED = 1;
+
+function extractFieldsFromDocument(doc) {
+  return Object.keys(dotnotation.serialize((doc)));
+}
+
+function truncateFieldToDepth(field, depth) {
+  if (!depth) {
+    return field;
+  }
+
+  return field
+    .split('.')
+    .slice(0, depth)
+    .join('.');
+}
 
 export default async function loadFields(
   dataService,
   ns,
-  filter = {},
+  { filter, sampleSize, maxDepth } = {},
   driverOptions = {}
 ) {
   const find = util.promisify(dataService.find.bind(dataService));
 
-  const docs = await find(ns, filter, {
-    limit: DEFAULT_SAMPLE_SIZE,
+  const docs = await find(ns, filter || {}, {
+    limit: sampleSize || DEFAULT_SAMPLE_SIZE,
     ...driverOptions
   });
 
-  const fieldsSet = docs.reduce((set, doc) => {
-    const docKeys = Object.keys(dotnotation.serialize((doc)));
-    return new Set([ ...set, docKeys]);
+  const fieldsSet = docs.reduce((previousSet, doc) => {
+    const fields = extractFieldsFromDocument(doc)
+      .map(field => truncateFieldToDepth(field, maxDepth));
+
+    return new Set([ ...previousSet, ...fields]);
   }, new Set());
 
   return Array
     .from(fieldsSet)
     .sort()
     .reduce((folded, field) => {
-      return { ...folded, [field]: 1 };
+      return { ...folded, [field]: ENABLED };
     }, {});
 }

--- a/src/modules/load-fields.js
+++ b/src/modules/load-fields.js
@@ -1,0 +1,30 @@
+import util from 'util';
+import dotnotation from '../utils/dotnotation';
+
+const DEFAULT_SAMPLE_SIZE = 50;
+
+export default async function loadFields(
+  dataService,
+  ns,
+  filter = {},
+  driverOptions = {}
+) {
+  const find = util.promisify(dataService.find.bind(dataService));
+
+  const docs = await find(ns, filter, {
+    limit: DEFAULT_SAMPLE_SIZE,
+    ...driverOptions
+  });
+
+  const fieldsSet = docs.reduce((set, doc) => {
+    const docKeys = Object.keys(dotnotation.serialize((doc)));
+    return new Set([ ...set, docKeys]);
+  }, new Set());
+
+  return Array
+    .from(fieldsSet)
+    .sort()
+    .reduce((folded, field) => {
+      return { ...folded, [field]: 1 };
+    }, {});
+}

--- a/src/modules/load-fields.spec.js
+++ b/src/modules/load-fields.spec.js
@@ -1,0 +1,62 @@
+import sinon from 'sinon';
+import loadFields from './load-fields';
+
+describe('loadFields', () => {
+  const fakeDataService = (err, docs) => {
+    return {
+      find: sinon.spy((ns, query, options, cb) => {
+        cb(err, docs);
+      })
+    };
+  };
+
+  it('folds all the fields from a set of documents', async() => {
+    const dataService = fakeDataService(null, [{a: '1'}, {b: '2'}]);
+    const fields = await loadFields(dataService, 'db1.coll1', {}, {});
+
+    expect(fields).to.deep.equal({
+      a: 1,
+      b: 1
+    });
+  });
+
+  it('folds nested fields', async() => {
+    const dataService = fakeDataService(null, [{
+      a: { b: '2' }
+    }, {
+      c: '3'
+    }]);
+    const fields = await loadFields(dataService, 'db1.coll1', {}, {});
+
+    expect(fields).to.deep.equal({
+      'a.b': 1,
+      c: 1
+    });
+  });
+
+  it('merges nested fields', async() => {
+    const dataService = fakeDataService(null, [{
+      a: { b: '2' }
+    }, {
+      a: { c: '3' }
+    }]);
+    const fields = await loadFields(dataService, 'db1.coll1', {}, {});
+
+    expect(fields).to.deep.equal({
+      'a.b': 1,
+      'a.c': 1
+    });
+  });
+
+  it('pass down arguments', async() => {
+    const dataService = fakeDataService(null, []);
+    await loadFields(dataService, 'db1.coll1', { x: 1 }, { maxTimeMs: 123 });
+
+    expect(dataService.find).to.have.been.calledOnceWith('db1.coll1', {
+      x: 1
+    }, {
+      limit: 50,
+      maxTimeMs: 123
+    });
+  });
+});

--- a/src/modules/load-fields.spec.js
+++ b/src/modules/load-fields.spec.js
@@ -48,15 +48,68 @@ describe('loadFields', () => {
     });
   });
 
+  it('truncates fields to maxDepth', async() => {
+    const dataService = fakeDataService(null, [
+      {
+        a: { b: { c: { d: 'x' } }}
+      }
+    ]);
+
+    const table = [
+      [1, 'a'],
+      [2, 'a.b'],
+      [3, 'a.b.c']
+    ];
+
+    for (const [maxDepth, expected] of table) {
+      const fields = await loadFields(
+        dataService, 'db1.coll1', {maxDepth}, {});
+
+      expect(fields).to.deep.equal({[expected]: 1});
+    }
+  });
+
+  it('works for docs with multiple fields', async() => {
+    const dataService = fakeDataService(null, [
+      {
+        _id: '1',
+        title: 'doc1',
+        year: '2003'
+      },
+      {
+        _id: '2',
+        title: 'doc2',
+        year: '2004'
+      }
+    ]);
+    const fields = await loadFields(dataService, 'db1.coll1', {}, {});
+
+    expect(fields).to.deep.equal({
+      _id: 1,
+      title: 1,
+      year: 1
+    });
+  });
+
   it('pass down arguments', async() => {
     const dataService = fakeDataService(null, []);
-    await loadFields(dataService, 'db1.coll1', { x: 1 }, { maxTimeMs: 123 });
-
-    expect(dataService.find).to.have.been.calledOnceWith('db1.coll1', {
-      x: 1
+    await loadFields(dataService, 'db1.coll1', {
+      filter: { x: 1 },
+      sampleSize: 10,
+      maxDepth: 3,
     }, {
-      limit: 50,
       maxTimeMs: 123
     });
+
+    expect(dataService.find).to.have.been.calledOnceWith(
+      'db1.coll1',
+      {
+        x: 1
+      },
+      {
+        limit: 10,
+        maxTimeMs: 123
+      }
+    );
   });
 });

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,3 +1,5 @@
+require('regenerator-runtime/runtime');
+
 const Enzyme = require('enzyme');
 const Adapter = require('enzyme-adapter-react-16');
 Enzyme.configure({ adapter: new Adapter() });


### PR DESCRIPTION
This is a pre-requisite to COMPASS-4154, since that contains a breaking change for import/export.

Rather than adapting this code to the new `dataService.sample` here we just switch back to a plain `find`, since in practice the accuracy is similar but the performance is better compared to a `$sample` aggregation.
