### PR TITLE
fix: fix “Ignore empty strings” (COMPASS-4458, COMPASS-4594)

### DIFF
--- a/src/components/import-options/import-options.jsx
+++ b/src/components/import-options/import-options.jsx
@@ -73,47 +73,47 @@ class ImportOptions extends PureComponent {
         />
         <fieldset>
           <legend className={style('legend')}>Options</legend>
-          {isCSV && (
+          {isCSV && (<React.Fragment>
             <div className={style('option')}>
               <label className={style('option-select-label')}>
                 Select delimiter
+                <select
+                  onChange={(evt) => {
+                    this.props.setDelimiter(evt.currentTarget.value);
+                  }}
+                  defaultValue={this.props.delimiter}
+                  className={style('option-select')}>
+                  <option value=",">comma</option>
+                  <option value={'\t'}>tab</option>
+                  <option value=";">semicolon</option>
+                  <option value=" ">space</option>
+                </select>
               </label>
-              <select
-                onChange={(evt) => {
-                  this.props.setDelimiter(evt.currentTarget.value);
-                }}
-                defaultValue={this.props.delimiter}
-                className={style('option-select')}>
-                <option value=",">comma</option>
-                <option value={'\t'}>tab</option>
-                <option value=";">semicolon</option>
-                <option value=" ">space</option>
-              </select>
             </div>
-          )}
+            <div className={style('option')}>
+              <label className={style('option-checkbox-label')}>
+                <input
+                  type="checkbox"
+                  checked={this.props.ignoreBlanks}
+                  onChange={() => {
+                    this.props.setIgnoreBlanks(!this.props.ignoreBlanks);
+                  }}
+                  className={style('option-checkbox')}
+                />
+                Ignore empty strings
+              </label>
+            </div>
+          </React.Fragment>)}
           <div className={style('option')}>
-            <input
-              type="checkbox"
-              checked={this.props.ignoreBlanks}
-              onChange={() => {
-                this.props.setIgnoreBlanks(!this.props.ignoreBlanks);
-              }}
-              className={style('option-checkbox')}
-            />
             <label className={style('option-checkbox-label')}>
-              Ignore empty strings
-            </label>
-          </div>
-          <div className={style('option')}>
-            <input
-              type="checkbox"
-              checked={this.props.stopOnErrors}
-              onChange={() => {
-                this.props.setStopOnErrors(!this.props.stopOnErrors);
-              }}
-              className={style('option-checkbox')}
-            />
-            <label className={style('option-checkbox-label')}>
+              <input
+                type="checkbox"
+                checked={this.props.stopOnErrors}
+                onChange={() => {
+                  this.props.setStopOnErrors(!this.props.stopOnErrors);
+                }}
+                className={style('option-checkbox')}
+              />
               Stop on errors
             </label>
           </div>

--- a/src/modules/import.js
+++ b/src/modules/import.js
@@ -33,6 +33,7 @@ import stripBomStream from 'strip-bom-stream';
 import mime from 'mime-types';
 
 import PROCESS_STATUS from 'constants/process-status';
+import FILE_TYPES from 'constants/file-types';
 import { appRegistryEmit, globalAppRegistryEmit } from 'modules/compass';
 
 import detectImportFile from 'utils/detect-import-file';
@@ -179,11 +180,12 @@ export const startImport = () => {
       fileIsMultilineJSON,
       fileStats: { size },
       delimiter,
-      ignoreBlanks,
+      ignoreBlanks: ignoreBlanks_,
       stopOnErrors,
       exclude,
       transform
     } = importData;
+    const ignoreBlanks = ignoreBlanks_ && fileType === FILE_TYPES.CSV;
 
     const source = fs.createReadStream(fileName, 'utf8');
 

--- a/src/utils/import-apply-types-and-projection.spec.js
+++ b/src/utils/import-apply-types-and-projection.spec.js
@@ -90,7 +90,7 @@ describe('import-apply-types-and-projection', () => {
       const res = transformProjectedTypesStream({
         exclude: [],
         transform: [],
-        removeBlanks: false
+        ignoreBlanks: false
       });
       expect(res.constructor.name).to.equal('PassThrough');
     });
@@ -344,7 +344,7 @@ describe('import-apply-types-and-projection', () => {
       });
     });
   });
-  describe('removeBlanks', () => {
+  describe('ignoreBlanks', () => {
     it('should not remove empty strings by default', () => {
       const source = {
         _id: 1,
@@ -359,7 +359,7 @@ describe('import-apply-types-and-projection', () => {
         _id: 1,
         empty: ''
       };
-      const result = apply(source, { transform: [], exclude: [], removeBlanks: true });
+      const result = apply(source, { transform: [], exclude: [], ignoreBlanks: true });
       expect(result).to.deep.equal({ _id: 1 });
     });
     it('should not convert ObjectID to Object', () => {
@@ -369,7 +369,7 @@ describe('import-apply-types-and-projection', () => {
       };
       const result = apply(source, {
         transform: ['_id', 'ObjectID'],
-        removeBlanks: true
+        ignoreBlanks: true
       });
       expect(result).to.deep.equal({
         _id: new ObjectID('5e74f99c182d2e9e6572c388')
@@ -384,7 +384,7 @@ describe('import-apply-types-and-projection', () => {
         falsed: false,
         undef: undefined
       };
-      const result = apply(source, { removeBlanks: true });
+      const result = apply(source, { ignoreBlanks: true });
       expect(result).to.deep.equal({
         _id: 1,
         nulled: null,
@@ -403,7 +403,7 @@ describe('import-apply-types-and-projection', () => {
         const transform = transformProjectedTypesStream({
           exclude: [],
           transform: [],
-          removeBlanks: false
+          ignoreBlanks: false
         });
         expect(transform).to.be.instanceOf(stream.PassThrough);
       });
@@ -418,7 +418,7 @@ describe('import-apply-types-and-projection', () => {
           }
         ]);
 
-        const transform = transformProjectedTypesStream({ removeBlanks: true });
+        const transform = transformProjectedTypesStream({ ignoreBlanks: true });
         let result;
         const dest = new stream.Writable({
           objectMode: true,


### PR DESCRIPTION
##### fix: use ignoreBlanks across codebase COMPASS-4594

The call to `transformProjectedTypesStream()` uses `ignoreBlanks`,
not `removeBlanks`, so pick one and stick with it. This renders
the `Ignore empty strings` checkbox functional again.

##### fix: dont display “Ignore empty strings” for JSON COMPASS-4458

For JSON, never ignore empty strings, and don’t display the checkbox.

As a drive-by fix, make the `<label>` elements wrap their corresponding
inputs so that they are associated with them.

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
