### PR TITLE
fix: export all fields in CSV COMPASS-4332

### DIFF
--- a/src/components/export-modal/export-modal.jsx
+++ b/src/components/export-modal/export-modal.jsx
@@ -33,7 +33,7 @@ import {
   startExport,
   sampleFields,
   cancelExport,
-  updateSelectableFields,
+  updateSelectedFields,
   changeExportStep,
   selectExportFileType,
   selectExportFileName,
@@ -82,7 +82,7 @@ class ExportModal extends PureComponent {
     cancelExport: PropTypes.func.isRequired,
     exportStep: PropTypes.string.isRequired,
     sampleFields: PropTypes.func.isRequired,
-    updateSelectableFields: PropTypes.func.isRequired,
+    updateSelectedFields: PropTypes.func.isRequired,
     isFullCollection: PropTypes.bool.isRequired,
     changeExportStep: PropTypes.func.isRequired,
     toggleFullCollection: PropTypes.func.isRequired,
@@ -220,7 +220,7 @@ class ExportModal extends PureComponent {
       <ExportSelectFields
         fields={this.props.fields}
         exportStep={this.props.exportStep}
-        updateSelectableFields={this.props.updateSelectableFields}/>
+        updateSelectedFields={this.props.updateSelectedFields}/>
     );
   }
 
@@ -364,7 +364,7 @@ export default connect(
     closeExport,
     sampleFields,
     cancelExport,
-    updateSelectableFields,
+    updateSelectedFields,
     changeExportStep,
     selectExportFileType,
     selectExportFileName,

--- a/src/components/export-modal/export-modal.jsx
+++ b/src/components/export-modal/export-modal.jsx
@@ -33,7 +33,7 @@ import {
   startExport,
   sampleFields,
   cancelExport,
-  updateFields,
+  updateSelectableFields,
   changeExportStep,
   selectExportFileType,
   selectExportFileName,
@@ -82,7 +82,7 @@ class ExportModal extends PureComponent {
     cancelExport: PropTypes.func.isRequired,
     exportStep: PropTypes.string.isRequired,
     sampleFields: PropTypes.func.isRequired,
-    updateFields: PropTypes.func.isRequired,
+    updateSelectableFields: PropTypes.func.isRequired,
     isFullCollection: PropTypes.bool.isRequired,
     changeExportStep: PropTypes.func.isRequired,
     toggleFullCollection: PropTypes.func.isRequired,
@@ -220,7 +220,7 @@ class ExportModal extends PureComponent {
       <ExportSelectFields
         fields={this.props.fields}
         exportStep={this.props.exportStep}
-        updateFields={this.props.updateFields}/>
+        updateSelectableFields={this.props.updateSelectableFields}/>
     );
   }
 
@@ -364,7 +364,7 @@ export default connect(
     closeExport,
     sampleFields,
     cancelExport,
-    updateFields,
+    updateSelectableFields,
     changeExportStep,
     selectExportFileType,
     selectExportFileName,

--- a/src/components/export-select-fields/export-select-fields.jsx
+++ b/src/components/export-select-fields/export-select-fields.jsx
@@ -17,7 +17,7 @@ class ExportSelectFields extends PureComponent {
   static propTypes = {
     fields: PropTypes.object.isRequired,
     exportStep: PropTypes.string.isRequired,
-    updateSelectableFields: PropTypes.func.isRequired,
+    updateSelectedFields: PropTypes.func.isRequired,
   };
 
   constructor(props) {
@@ -43,7 +43,7 @@ class ExportSelectFields extends PureComponent {
   handleFieldCheckboxChange = (evt) => {
     const fields = Object.assign({}, this.props.fields);
     fields[`${evt.target.name}`] ^= 1; // flip 1/0 to its opposite
-    this.props.updateSelectableFields(fields);
+    this.props.updateSelectedFields(fields);
   }
 
   handleHeaderCheckboxChange = () => {
@@ -55,7 +55,7 @@ class ExportSelectFields extends PureComponent {
       Object.keys(fields).map(f => (fields[f] = 1));
     }
 
-    this.props.updateSelectableFields(fields);
+    this.props.updateSelectedFields(fields);
   }
 
   handleInputOnBlur = () => {
@@ -69,7 +69,7 @@ class ExportSelectFields extends PureComponent {
       // assign current entry to the end of the fields list
       const fields = Object.assign({}, this.props.fields, obj);
 
-      this.props.updateSelectableFields(fields);
+      this.props.updateSelectedFields(fields);
       // this will trigger 'componentDidMount()` which focuses on input field to
       // keep adding missing fields
       this.setState({ addingFields: true });

--- a/src/components/export-select-fields/export-select-fields.jsx
+++ b/src/components/export-select-fields/export-select-fields.jsx
@@ -17,7 +17,7 @@ class ExportSelectFields extends PureComponent {
   static propTypes = {
     fields: PropTypes.object.isRequired,
     exportStep: PropTypes.string.isRequired,
-    updateFields: PropTypes.func.isRequired,
+    updateSelectableFields: PropTypes.func.isRequired,
   };
 
   constructor(props) {
@@ -43,7 +43,7 @@ class ExportSelectFields extends PureComponent {
   handleFieldCheckboxChange = (evt) => {
     const fields = Object.assign({}, this.props.fields);
     fields[`${evt.target.name}`] ^= 1; // flip 1/0 to its opposite
-    this.props.updateFields(fields);
+    this.props.updateSelectableFields(fields);
   }
 
   handleHeaderCheckboxChange = () => {
@@ -55,7 +55,7 @@ class ExportSelectFields extends PureComponent {
       Object.keys(fields).map(f => (fields[f] = 1));
     }
 
-    this.props.updateFields(fields);
+    this.props.updateSelectableFields(fields);
   }
 
   handleInputOnBlur = () => {
@@ -69,7 +69,7 @@ class ExportSelectFields extends PureComponent {
       // assign current entry to the end of the fields list
       const fields = Object.assign({}, this.props.fields, obj);
 
-      this.props.updateFields(fields);
+      this.props.updateSelectableFields(fields);
       // this will trigger 'componentDidMount()` which focuses on input field to
       // keep adding missing fields
       this.setState({ addingFields: true });

--- a/src/modules/export.spec.js
+++ b/src/modules/export.spec.js
@@ -35,6 +35,7 @@ describe('export [module]', () => {
             query: { filter: {} },
             error: true,
             fields: {},
+            allFields: {},
             fileName: '',
             fileType: FILE_TYPES.JSON,
             status: PROCESS_STATUS.FAILED,
@@ -59,6 +60,7 @@ describe('export [module]', () => {
             query: { filter: {} },
             error: null,
             fields: {},
+            allFields: {},
             fileName: '',
             fileType: FILE_TYPES.JSON,
             status: PROCESS_STATUS.COMPLETED,
@@ -83,6 +85,7 @@ describe('export [module]', () => {
             query: { filter: {} },
             error: null,
             fields: {},
+            allFields: {},
             fileName: '',
             fileType: FILE_TYPES.JSON,
             status: PROCESS_STATUS.CANCELED,
@@ -107,6 +110,7 @@ describe('export [module]', () => {
             query: { filter: {} },
             error: true,
             fields: {},
+            allFields: {},
             fileName: '',
             fileType: FILE_TYPES.JSON,
             status: PROCESS_STATUS.FAILED,
@@ -140,6 +144,7 @@ describe('export [module]', () => {
           query: { filter: {} },
           error: null,
           fields: {},
+          allFields: {},
           fileName: '',
           fileType: FILE_TYPES.JSON,
           status: PROCESS_STATUS.UNSPECIFIED,
@@ -158,6 +163,7 @@ describe('export [module]', () => {
           exportStep: EXPORT_STEP.QUERY,
           exportedDocsCount: 0,
           fields: {},
+          allFields: {},
           progress: 0,
           isFullCollection: false,
           query: { filter: {}},
@@ -182,6 +188,7 @@ describe('export [module]', () => {
           exportStep: EXPORT_STEP.QUERY,
           exportedDocsCount: 0,
           fields: {},
+          allFields: {},
           isFullCollection: false,
           query: { filter: {}},
           error: null,
@@ -204,6 +211,7 @@ describe('export [module]', () => {
           exportStep: EXPORT_STEP.QUERY,
           isFullCollection: false,
           fields: {},
+          allFields: {},
           query: { filter: {}},
           error: null,
           fileName: '',
@@ -213,9 +221,9 @@ describe('export [module]', () => {
       });
     });
 
-    context('when the action type is UPDATE_FIELDS', () => {
+    context('when the action type is UPDATE_SELECTABLE_FIELDS', () => {
       const fields = { 'field': 1, 'field2': 0 };
-      const action = actions.updateFields(fields);
+      const action = actions.updateSelectableFields(fields);
 
       it('returns the new state', () => {
         expect(reducer(undefined, action)).to.deep.equal({
@@ -226,6 +234,30 @@ describe('export [module]', () => {
           isFullCollection: false,
           query: { filter: {}},
           fields: fields,
+          allFields: {},
+          progress: 0,
+          error: null,
+          fileName: '',
+          fileType: 'json',
+          status: 'UNSPECIFIED'
+        });
+      });
+    });
+
+    context('when the action type is UPDATE_ALL_FIELDS', () => {
+      const fields = { 'field': 1, 'field2': 0 };
+      const action = actions.updateAllFields(fields);
+
+      it('returns the new state', () => {
+        expect(reducer(undefined, action)).to.deep.equal({
+          isOpen: false,
+          count: 0,
+          exportedDocsCount: 0,
+          exportStep: EXPORT_STEP.QUERY,
+          isFullCollection: false,
+          query: { filter: {}},
+          fields: {},
+          allFields: fields,
           progress: 0,
           error: null,
           fileName: '',
@@ -258,6 +290,7 @@ describe('export [module]', () => {
           query: { filter: {} },
           error: null,
           fields: {},
+          allFields: {},
           fileName: '',
           fileType: FILE_TYPES.JSON,
           status: PROCESS_STATUS.UNSPECIFIED,

--- a/src/modules/export.spec.js
+++ b/src/modules/export.spec.js
@@ -221,9 +221,9 @@ describe('export [module]', () => {
       });
     });
 
-    context('when the action type is UPDATE_SELECTABLE_FIELDS', () => {
+    context('when the action type is UPDATE_SELECTED_FIELDS', () => {
       const fields = { 'field': 1, 'field2': 0 };
-      const action = actions.updateSelectableFields(fields);
+      const action = actions.updateSelectedFields(fields);
 
       it('returns the new state', () => {
         expect(reducer(undefined, action)).to.deep.equal({

--- a/src/modules/load-fields.js
+++ b/src/modules/load-fields.js
@@ -19,10 +19,10 @@ function truncateFieldToDepth(field, depth) {
     .join('.');
 }
 
-export default async function loadFields(
+export async function loadFields(
   dataService,
   ns,
-  { filter, sampleSize, maxDepth } = {},
+  { filter, sampleSize } = {},
   driverOptions = {}
 ) {
   const find = util.promisify(dataService.find.bind(dataService));
@@ -39,11 +39,11 @@ export default async function loadFields(
     }
   }
   const allFields = [...allFieldsSet].sort();
-  const selectableFields = allFields
-    .map(field => truncateFieldToDepth(field, maxDepth));
+  return Object.fromEntries(allFields.map(field => [field, ENABLED]));
+}
 
-  return {
-    all: Object.fromEntries(allFields.map(field => [field, ENABLED])),
-    selectable: Object.fromEntries(selectableFields.map(field => [field, ENABLED]))
-  };
+export function getSelectableFields(fields, { maxDepth } = {}) {
+  const selectableFields = Object.keys(fields)
+    .map(field => truncateFieldToDepth(field, maxDepth));
+  return Object.fromEntries(selectableFields.map(field => [field, ENABLED]));
 }

--- a/src/modules/load-fields.js
+++ b/src/modules/load-fields.js
@@ -32,17 +32,18 @@ export default async function loadFields(
     ...driverOptions
   });
 
-  const fieldsSet = docs.reduce((previousSet, doc) => {
-    const fields = extractFieldsFromDocument(doc)
-      .map(field => truncateFieldToDepth(field, maxDepth));
+  const allFieldsSet = new Set();
+  for (const doc of docs) {
+    for (const field of extractFieldsFromDocument(doc)) {
+      allFieldsSet.add(field);
+    }
+  }
+  const allFields = [...allFieldsSet].sort();
+  const selectableFields = allFields
+    .map(field => truncateFieldToDepth(field, maxDepth));
 
-    return new Set([ ...previousSet, ...fields]);
-  }, new Set());
-
-  return Array
-    .from(fieldsSet)
-    .sort()
-    .reduce((folded, field) => {
-      return { ...folded, [field]: ENABLED };
-    }, {});
+  return {
+    all: Object.fromEntries(allFields.map(field => [field, ENABLED])),
+    selectable: Object.fromEntries(selectableFields.map(field => [field, ENABLED]))
+  };
 }

--- a/src/modules/load-fields.spec.js
+++ b/src/modules/load-fields.spec.js
@@ -15,8 +15,14 @@ describe('loadFields', () => {
     const fields = await loadFields(dataService, 'db1.coll1', {}, {});
 
     expect(fields).to.deep.equal({
-      a: 1,
-      b: 1
+      all: {
+        a: 1,
+        b: 1
+      },
+      selectable: {
+        a: 1,
+        b: 1
+      }
     });
   });
 
@@ -29,8 +35,14 @@ describe('loadFields', () => {
     const fields = await loadFields(dataService, 'db1.coll1', {}, {});
 
     expect(fields).to.deep.equal({
-      'a.b': 1,
-      c: 1
+      all: {
+        'a.b': 1,
+        c: 1
+      },
+      selectable: {
+        'a.b': 1,
+        c: 1
+      }
     });
   });
 
@@ -43,8 +55,14 @@ describe('loadFields', () => {
     const fields = await loadFields(dataService, 'db1.coll1', {}, {});
 
     expect(fields).to.deep.equal({
-      'a.b': 1,
-      'a.c': 1
+      all: {
+        'a.b': 1,
+        'a.c': 1
+      },
+      selectable: {
+        'a.b': 1,
+        'a.c': 1
+      }
     });
   });
 
@@ -65,7 +83,14 @@ describe('loadFields', () => {
       const fields = await loadFields(
         dataService, 'db1.coll1', {maxDepth}, {});
 
-      expect(fields).to.deep.equal({[expected]: 1});
+      expect(fields).to.deep.equal({
+        all: {
+          'a.b.c.d': 1
+        },
+        selectable: {
+          [expected]: 1
+        }
+      });
     }
   });
 
@@ -85,9 +110,16 @@ describe('loadFields', () => {
     const fields = await loadFields(dataService, 'db1.coll1', {}, {});
 
     expect(fields).to.deep.equal({
-      _id: 1,
-      title: 1,
-      year: 1
+      all: {
+        _id: 1,
+        title: 1,
+        year: 1
+      },
+      selectable: {
+        _id: 1,
+        title: 1,
+        year: 1
+      }
     });
   });
 

--- a/src/modules/load-fields.spec.js
+++ b/src/modules/load-fields.spec.js
@@ -1,5 +1,5 @@
 import sinon from 'sinon';
-import loadFields from './load-fields';
+import { loadFields, getSelectableFields } from './load-fields';
 
 describe('loadFields', () => {
   const fakeDataService = (err, docs) => {
@@ -15,14 +15,8 @@ describe('loadFields', () => {
     const fields = await loadFields(dataService, 'db1.coll1', {}, {});
 
     expect(fields).to.deep.equal({
-      all: {
-        a: 1,
-        b: 1
-      },
-      selectable: {
-        a: 1,
-        b: 1
-      }
+      a: 1,
+      b: 1
     });
   });
 
@@ -35,14 +29,8 @@ describe('loadFields', () => {
     const fields = await loadFields(dataService, 'db1.coll1', {}, {});
 
     expect(fields).to.deep.equal({
-      all: {
-        'a.b': 1,
-        c: 1
-      },
-      selectable: {
-        'a.b': 1,
-        c: 1
-      }
+      'a.b': 1,
+      c: 1
     });
   });
 
@@ -55,43 +43,24 @@ describe('loadFields', () => {
     const fields = await loadFields(dataService, 'db1.coll1', {}, {});
 
     expect(fields).to.deep.equal({
-      all: {
-        'a.b': 1,
-        'a.c': 1
-      },
-      selectable: {
-        'a.b': 1,
-        'a.c': 1
-      }
+      'a.b': 1,
+      'a.c': 1
     });
   });
 
-  it('truncates fields to maxDepth', async() => {
+  it('does not truncate fields', async() => {
     const dataService = fakeDataService(null, [
       {
         a: { b: { c: { d: 'x' } }}
       }
     ]);
 
-    const table = [
-      [1, 'a'],
-      [2, 'a.b'],
-      [3, 'a.b.c']
-    ];
+    const fields = await loadFields(
+      dataService, 'db1.coll1', {}, {});
 
-    for (const [maxDepth, expected] of table) {
-      const fields = await loadFields(
-        dataService, 'db1.coll1', {maxDepth}, {});
-
-      expect(fields).to.deep.equal({
-        all: {
-          'a.b.c.d': 1
-        },
-        selectable: {
-          [expected]: 1
-        }
-      });
-    }
+    expect(fields).to.deep.equal({
+      'a.b.c.d': 1
+    });
   });
 
   it('works for docs with multiple fields', async() => {
@@ -110,16 +79,9 @@ describe('loadFields', () => {
     const fields = await loadFields(dataService, 'db1.coll1', {}, {});
 
     expect(fields).to.deep.equal({
-      all: {
-        _id: 1,
-        title: 1,
-        year: 1
-      },
-      selectable: {
-        _id: 1,
-        title: 1,
-        year: 1
-      }
+      _id: 1,
+      title: 1,
+      year: 1
     });
   });
 
@@ -128,7 +90,6 @@ describe('loadFields', () => {
     await loadFields(dataService, 'db1.coll1', {
       filter: { x: 1 },
       sampleSize: 10,
-      maxDepth: 3,
     }, {
       maxTimeMs: 123
     });
@@ -143,5 +104,26 @@ describe('loadFields', () => {
         maxTimeMs: 123
       }
     );
+  });
+});
+
+describe('getSelectableFields', () => {
+  it('truncates fields as specified by maxDepth', () => {
+    const allFields = { 'a.b.c.d': 1 };
+
+    const table = [
+      [1, 'a'],
+      [2, 'a.b'],
+      [3, 'a.b.c'],
+      [4, 'a.b.c.d']
+    ];
+
+    for (const [maxDepth, expected] of table) {
+      const fields = getSelectableFields(allFields, { maxDepth });
+
+      expect(fields).to.deep.equal({
+        [expected]: 1
+      });
+    }
   });
 });

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -45,9 +45,10 @@ export const createJSONFormatter = function({ brackets = true } = {}) {
 /**
  * @returns {Stream.Transform}
  */
-export const createCSVFormatter = function() {
+export const createCSVFormatter = function({ columns }) {
   return csv.format({
-    headers: true,
+    headers: columns,
+    alwaysWriteHeaders: true,
     transform: row => {
       return flatten(row);
     }

--- a/src/utils/formatters.spec.js
+++ b/src/utils/formatters.spec.js
@@ -125,7 +125,9 @@ describe('formatters', () => {
         {_id: {foo: 'bar'}}
       ];
       const source = stream.Readable.from(docs);
-      const formatter = createCSVFormatter();
+      const formatter = createCSVFormatter({
+        columns: ['_id.foo']
+      });
       const dest = fs.createWriteStream(FIXTURES.CSV_FLAT_HEADERS);
 
       return pipeline(source, formatter, dest)
@@ -150,7 +152,7 @@ describe('formatters', () => {
         {_id: new ObjectID('5e5ea7558d35931a05eafec0')},
       ];
       const source = stream.Readable.from(docs);
-      const formatter = createCSVFormatter();
+      const formatter = createCSVFormatter({ columns: ['_id'] });
       const dest = fs.createWriteStream(FIXTURES.CSV_FLAT_HEADERS);
 
       return pipeline(source, formatter, dest)


### PR DESCRIPTION
fast-csv autodetects columns based on the first row of data
when we don’t pass in the headers explicitly.

Start passing in the headers explicitly so that all selected
columns are included in the resulting CSV.

<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
