### PR TITLE
refactor: Refactor collection stream to report progress better and adjust import UI to represent progress im a more meaningful way COMPASS-4571

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,7 +10,8 @@
   "rules": {
     "camelcase": 1,
     "no-var": 1,
-    "no-trailing-spaces": 1
+    "no-trailing-spaces": 1,
+    "react/no-multi-comp": 0
   },
   "extends": [
     "mongodb-js/node",

--- a/electron/renderer/components/import-export/import-export.jsx
+++ b/electron/renderer/components/import-export/import-export.jsx
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Plugin from 'plugin';

--- a/examples/error-box.stories.js
+++ b/examples/error-box.stories.js
@@ -36,9 +36,9 @@ storiesOf('Examples', module)
         <h2 style={stateName}>No Error</h2>
         <ErrorBox />
         <h2 style={stateName}>Simple Error</h2>
-        <ErrorBox error={getASimpleError()} />
+        <ErrorBox message={getASimpleError().message} />
         <h2 style={stateName}>JSON Parsing Error</h2>
-        <ErrorBox error={getAnImportError()} />
+        <ErrorBox message={getAnImportError().message} />
       </div>
     );
   });

--- a/src/components/error-box/error-box.jsx
+++ b/src/components/error-box/error-box.jsx
@@ -19,19 +19,19 @@ const ANSI_TO_HTML_OPTIONS = {
   stream: false
 };
 
-const getPrettyErrorMessage = function(err) {
-  return new ANSIConverter(ANSI_TO_HTML_OPTIONS).toHtml(err.message);
+function getPrettyErrorMessage(message) {
+  return new ANSIConverter(ANSI_TO_HTML_OPTIONS).toHtml(message);
 };
 
 class ErrorBox extends PureComponent {
   static propTypes = {
-    error: PropTypes.object
+    message: PropTypes.string
   };
   render() {
-    if (!this.props.error) {
+    if (!this.props.message) {
       return null;
     }
-    const prettyError = getPrettyErrorMessage(this.props.error);
+    const prettyError = getPrettyErrorMessage(this.props.message);
     return (
       <div
         className={style()}

--- a/src/components/export-modal/export-modal.jsx
+++ b/src/components/export-modal/export-modal.jsx
@@ -316,7 +316,9 @@ class ExportModal extends PureComponent {
           {this.renderExportOptions()}
           {this.renderSelectFields()}
           {this.renderSelectOutput()}
-          <ErrorBox error={this.props.error} />
+          {Boolean(this.props.error) && (
+            <ErrorBox message={this.props.error.message} />
+          )}
         </Modal.Body>
         <Modal.Footer>
           {this.renderBackButton()}

--- a/src/components/import-modal/import-modal.jsx
+++ b/src/components/import-modal/import-modal.jsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { PureComponent, useMemo, useState, useCallback } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Modal } from 'react-bootstrap';
@@ -6,8 +6,10 @@ import { TextButton } from 'hadron-react-buttons';
 import fileOpenDialog from 'utils/file-open-dialog';
 import {
   FINISHED_STATUSES,
+  COMPLETED_STATUSES,
   STARTED,
   COMPLETED,
+  COMPLETED_WITH_ERRORS,
   CANCELED,
   FAILED,
   UNSPECIFIED
@@ -17,7 +19,7 @@ import ErrorBox from 'components/error-box';
 import ImportPreview from 'components/import-preview';
 import ImportOptions from 'components/import-options';
 import FILE_TYPES from 'constants/file-types';
-
+import formatNumber from 'utils/format-number.js';
 import {
   startImport,
   cancelImport,
@@ -30,6 +32,11 @@ import {
   toggleIncludeField,
   setFieldType
 } from 'modules/import';
+import styles from './import-modal.less';
+import createStyler from 'utils/styler.js';
+import classnames from 'classnames';
+
+const style = createStyler(styles, 'import-modal');
 
 /**
  * Progress messages.
@@ -38,8 +45,77 @@ const MESSAGES = {
   [STARTED]: 'Importing documents...',
   [CANCELED]: 'Import canceled',
   [COMPLETED]: 'Import completed',
-  [FAILED]: 'Error importing',
+  [COMPLETED_WITH_ERRORS]: 'Import completed with following errors:',
+  [FAILED]: 'Failed to import with the following error:',
   [UNSPECIFIED]: ''
+};
+
+const SHOW_MORE_STEP = 10;
+
+const DEFAULT_VISIBLE_ERRORS_COUNT = 3;
+
+function ErrorsList({ errors }) {
+  const [visibleErrorsCount, setVisibleErrorsCount] = useState(
+    DEFAULT_VISIBLE_ERRORS_COUNT
+  );
+
+  const normalizedErrorMessages = useMemo(() => {
+    // BulkWrite and WriteErrors can have identical messages, we want to leave
+    // only unique errors for display. We also reversing to show recent errors
+    // higher in the list (TODO: check with Claudia)
+    return [...new Set(errors.map((err) => err.message))].reverse();
+  }, [errors]);
+
+  const showMoreCount = useMemo(() => {
+    return formatNumber(
+      Math.min(
+        SHOW_MORE_STEP,
+        normalizedErrorMessages.length - visibleErrorsCount
+      )
+    );
+  }, [normalizedErrorMessages.length, visibleErrorsCount]);
+
+  const increaseVisibleErrorsCount = useCallback(() => {
+    setVisibleErrorsCount((currCount) => currCount + SHOW_MORE_STEP);
+  });
+
+  if (normalizedErrorMessages.length === 0) {
+    return (
+      <div className={style('errors')}>
+        <ErrorBox message={normalizedErrorMessages[0]} />
+      </div>
+    );
+  }
+
+  return (
+    <div className={style('errors')}>
+      <ul className={style('errors-list')}>
+        {normalizedErrorMessages.slice(0, visibleErrorsCount).map((message) => (
+          <li key={message} className={style('errors-list-item')}>
+            <ErrorBox message={message} />
+          </li>
+        ))}
+      </ul>
+      {showMoreCount > 0 && (
+        <button
+          className={classnames(
+            'btn btn-default btn-xs',
+            style('show-more-errors-button')
+          )}
+          onClick={increaseVisibleErrorsCount}
+        >
+          <i className="fa fa-arrow-down" aria-hidden="true" />
+          <span className={style('show-more-errors-button-text')}>
+            Show {showMoreCount} more errors
+          </span>
+        </button>
+      )}
+    </div>
+  );
+}
+
+ErrorsList.propTypes = {
+  errors: PropTypes.array
 };
 
 class ImportModal extends PureComponent {
@@ -53,7 +129,7 @@ class ImportModal extends PureComponent {
     /**
      * Shared
      */
-    error: PropTypes.object,
+    errors: PropTypes.array,
     status: PropTypes.string.isRequired,
 
     /**
@@ -73,9 +149,11 @@ class ImportModal extends PureComponent {
     /**
      * See `<ProgressBar />`
      */
-    progress: PropTypes.number.isRequired,
+    docsTotal: PropTypes.number,
+    docsProcessed: PropTypes.number,
     docsWritten: PropTypes.number,
     guesstimatedDocsTotal: PropTypes.number,
+    guesstimatedDocsProcessed: PropTypes.number,
 
     /**
      * See `<ImportPreview />`
@@ -120,7 +198,7 @@ class ImportModal extends PureComponent {
    * @returns {Boolean}
    */
   wasImportSuccessful() {
-    return this.props.status === COMPLETED;
+    return COMPLETED_STATUSES.includes(this.props.status);
   }
 
   renderDoneButton() {
@@ -137,7 +215,7 @@ class ImportModal extends PureComponent {
   }
 
   renderCancelButton() {
-    if (this.props.status !== COMPLETED) {
+    if (!this.wasImportSuccessful()) {
       return (
         <TextButton
           className="btn btn-default btn-sm"
@@ -191,6 +269,20 @@ class ImportModal extends PureComponent {
    * @returns {React.Component} The component.
    */
   render() {
+    const {
+      status,
+      errors,
+      docsTotal,
+      docsProcessed,
+      docsWritten,
+      guesstimatedDocsTotal,
+      guesstimatedDocsProcessed,
+    } = this.props;
+
+    // docsTotal is set to actual value only at the very end of processing a
+    // stream of documents
+    const isGuesstimated = docsTotal === -1;
+
     return (
       <Modal show={this.props.open} onHide={this.handleClose} backdrop="static">
         <Modal.Header closeButton>
@@ -212,14 +304,30 @@ class ImportModal extends PureComponent {
           />
           {this.renderImportPreview()}
           <ProgressBar
-            progress={this.props.progress}
             status={this.props.status}
-            message={MESSAGES[this.props.status]}
+            withErrors={errors.length > 0}
             cancel={this.props.cancelImport}
-            docsWritten={this.props.docsWritten}
-            guesstimatedDocsTotal={this.props.guesstimatedDocsTotal}
+            docsWritten={docsWritten}
+            docsProcessed={Math.max(docsProcessed, guesstimatedDocsProcessed)}
+            docsTotal={
+              // When guesstimating, guessed total might be too low, in that
+              // case the most reasonable thing to do would be to fallback to
+              // currently processed number
+              isGuesstimated
+                ? Math.max(docsProcessed, guesstimatedDocsTotal)
+                : docsTotal
+            }
+            progressLabel={(written, total) =>
+              `${written}\u00a0/\u00a0${isGuesstimated ? '~' : ''}${total}`
+            }
+            progressTitle={(written, total) =>
+              `Imported ${written} out of ${
+                isGuesstimated ? 'approximately ' : ''
+              }${total} documents`
+            }
+            message={MESSAGES[status]}
           />
-          <ErrorBox error={this.props.error} />
+          <ErrorsList errors={errors} />
         </Modal.Body>
         <Modal.Footer>
           {this.renderCancelButton()}
@@ -241,14 +349,16 @@ class ImportModal extends PureComponent {
  */
 const mapStateToProps = (state) => ({
   ns: state.ns,
-  progress: state.importData.progress,
   open: state.importData.isOpen,
-  error: state.importData.error,
+  errors: state.importData.errors,
   fileType: state.importData.fileType,
   fileName: state.importData.fileName,
   status: state.importData.status,
+  docsTotal: state.importData.docsTotal,
+  docsProcessed: state.importData.docsProcessed,
   docsWritten: state.importData.docsWritten,
   guesstimatedDocsTotal: state.importData.guesstimatedDocsTotal,
+  guesstimatedDocsProcessed: state.importData.guesstimatedDocsProcessed,
   delimiter: state.importData.delimiter,
   stopOnErrors: state.importData.stopOnErrors,
   ignoreBlanks: state.importData.ignoreBlanks,

--- a/src/components/import-modal/import-modal.jsx
+++ b/src/components/import-modal/import-modal.jsx
@@ -62,7 +62,7 @@ function ErrorsList({ errors }) {
   const normalizedErrorMessages = useMemo(() => {
     // BulkWrite and WriteErrors can have identical messages, we want to leave
     // only unique errors for display. We also reversing to show recent errors
-    // higher in the list (TODO: check with Claudia)
+    // higher in the list
     return [...new Set(errors.map((err) => err.message))].reverse();
   }, [errors]);
 

--- a/src/components/import-modal/import-modal.less
+++ b/src/components/import-modal/import-modal.less
@@ -1,0 +1,25 @@
+@import (reference) '~less/compass/_theme.less';
+
+.import-modal {
+  &-errors {
+    margin-top: 10px;
+  }
+
+  &-errors-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  &-errors-list-item:not(:first-child) {
+    margin-top: 10px;
+}
+
+  &-show-more-errors-button {
+    margin-top: 10px;
+
+    &-text {
+      margin-left: 5px;
+    }
+  }
+}

--- a/src/components/import-preview/import-preview.jsx
+++ b/src/components/import-preview/import-preview.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-multi-comp */
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import styles from './import-preview.less';

--- a/src/components/progress-bar/progress-bar.less
+++ b/src/components/progress-bar/progress-bar.less
@@ -5,6 +5,7 @@
   border-radius: 5px;
   height: 10px;
   background-color: #e7eeec;
+  overflow: hidden;
 
   &-chart-wrapper {
     padding-top: 20px;
@@ -12,22 +13,31 @@
   }
 
   &-bar {
+    position: absolute;
     height: 10px;
-    transition: width 0.2s ease;
+    transition: width 0.2s linear, background-color 0.2s ease;
     display: block;
     border-radius: 5px;
-    background: #007cad;
-    // background: linear-gradient(to right, #007cad, 50%, #00b3d6);
+    background-color: #007cad;
 
     &-is-canceled {
-      background: #b8c4c2;
+      background-color: #b8c4c2;
     }
+
     &-is-failed {
-      background: #d65d33;
+      background-color: #d65d33;
     }
 
     &-is-completed {
       background-color: @green2;
+    }
+
+    &-is-with-errors {
+      background-color: @alertOrange;
+    }
+
+    &-is-secondary {
+      opacity: 0.4;
     }
   }
 
@@ -45,11 +55,21 @@
       }
 
       &-cancel {
+        margin: 0;
         margin-left: 10px;
         color: #0d47a1;
+        border: none;
+        padding: 0;
+        background: none;
         cursor: pointer;
       }
+
+      &-cancel:hover,
+      &-cancel:focus {
+        text-decoration: underline;
+      }
     }
+
     &-stats {
       flex-grow: 0;
       margin-bottom: 0;

--- a/src/components/select-field-type/select-field-type.jsx
+++ b/src/components/select-field-type/select-field-type.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-multi-comp */
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 

--- a/src/constants/process-status.js
+++ b/src/constants/process-status.js
@@ -1,6 +1,7 @@
 export const STARTED = 'STARTED';
 export const CANCELED = 'CANCELED';
 export const COMPLETED = 'COMPLETED';
+export const COMPLETED_WITH_ERRORS = 'COMPLETED_WITH_ERRORS';
 export const FAILED = 'FAILED';
 export const UNSPECIFIED = 'UNSPECIFIED';
 
@@ -12,7 +13,8 @@ export const PROCESS_STATUS = {
   CANCELED,
   COMPLETED,
   FAILED,
-  UNSPECIFIED
+  UNSPECIFIED,
+  COMPLETED_WITH_ERRORS
 };
 
 /**
@@ -21,7 +23,13 @@ export const PROCESS_STATUS = {
 export const FINISHED_STATUSES = [
   CANCELED,
   COMPLETED,
+  COMPLETED_WITH_ERRORS,
   FAILED
+];
+
+export const COMPLETED_STATUSES = [
+  COMPLETED,
+  COMPLETED_WITH_ERRORS,
 ];
 
 export default PROCESS_STATUS;

--- a/src/modules/import.spec.js
+++ b/src/modules/import.spec.js
@@ -151,15 +151,17 @@ describe('import [module]', () => {
 
           expect(result).to.be.deep.equal({
             isOpen: false,
-            progress: 0,
-            error: null,
+            errors: [],
             fileName: '',
             fileIsMultilineJSON: false,
             useHeaderLines: true,
             status: 'UNSPECIFIED',
             fileStats: null,
+            docsTotal: -1,
+            docsProcessed: 0,
             docsWritten: 0,
             guesstimatedDocsTotal: 0,
+            guesstimatedDocsProcessed: 0,
             delimiter: ',',
             stopOnErrors: false,
             ignoreBlanks: true,
@@ -172,8 +174,8 @@ describe('import [module]', () => {
           });
 
           resolve(test);
-          // done();
         });
+
         test.store.dispatch(selectImportFileName(fileName));
 
         expect(test.store.getActions()).to.deep.equal([

--- a/src/utils/import-parser.js
+++ b/src/utils/import-parser.js
@@ -119,16 +119,18 @@ export const createProgressStream = function(fileSize, onProgress) {
     time: PROGRESS_UPDATE_INTERVAL // NOTE: ask lucas how time is different from an interval here.
   });
 
-  // eslint-disable-next-line camelcase
-  function update_import_progress_throttled(info) {
+  function updateProgress(info) {
     onProgress(null, info);
   }
-  const updateProgress = throttle(
-    update_import_progress_throttled,
+
+  const updateProgressThrottled = throttle(
+    updateProgress,
     PROGRESS_UPDATE_INTERVAL,
     { leading: true }
   );
-  progress.on('progress', updateProgress);
+
+  progress.on('progress', updateProgressThrottled);
+
   return progress;
 };
 


### PR DESCRIPTION
This PR addresses the original issue specified in COMPASS-4571 but also makes several adjustments to the UI as without them the numbers reported by fixed `collection-stream` were not represented in the UI in a way that makes sense (e.g., you could get a progress bar that is filled only half way through when the UI reports "100% completed" progress, or a green progress bar with error reported, or only one error reported when not a single document was uploaded). Following is a comparison of some states before and after the change:

### Successful Upload

https://user-images.githubusercontent.com/5036933/111973927-47278d00-8aff-11eb-9402-4474cf66efab.mp4

https://user-images.githubusercontent.com/5036933/111972134-67564c80-8afd-11eb-92b5-adb001a3cc6f.mp4

### Errors on Upload, `stopOnErrors` is `false`

https://user-images.githubusercontent.com/5036933/111973947-4c84d780-8aff-11eb-81e9-754c22712110.mp4

https://user-images.githubusercontent.com/5036933/111972154-6fae8780-8afd-11eb-9bb2-1607e5be77a5.mp4

### Errors on Upload, `stopOnErrors` is `true`

https://user-images.githubusercontent.com/5036933/111973965-50b0f500-8aff-11eb-86b7-1d6a731c6684.mp4

https://user-images.githubusercontent.com/5036933/111972185-776e2c00-8afd-11eb-83a7-53aa8bb9e136.mp4

I synced on this updated UI with Claudia and she is okay with releasing this as is, but we probably want to have a follow up that addresses how multiple errors are displayed to make it more accessible




