### PR TITLE
fix(collection-stream): Handle null result when bulkWrite fails

### DIFF
--- a/src/utils/collection-stream.js
+++ b/src/utils/collection-stream.js
@@ -87,7 +87,11 @@ class WritableCollectionStream extends Writable {
         // result can still be accessed on the error instance
         const result = (err && err.result && err.result.result) || res;
 
-        this._mergeBulkOpResult(result);
+        // Driver seems to return null instead of undefined in some rare cases
+        // when the operation ends in error, instead of relying on
+        // `_mergeBulkOpResult` default argument substitution, we need to keep
+        // this OR expression here
+        this._mergeBulkOpResult(result || {});
 
         this.docsProcessed += documents.length;
 


### PR DESCRIPTION
Instead of returning `(err, undefined)` in the `bulkWrite` callback, driver seems to return `(err, null)` in some rare cases, which breaks `_mergeBulkOpResult` call and fails the import even if `stopOnError` is `false`, this PR handles the corner case by making sure that `_mergeBulkOpResult` will always gets an object